### PR TITLE
:pushpin: Pin mozilla-django-oidc to <2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     psycopg2
     django-better-admin-arrayfield
     django-solo
-    mozilla-django-oidc
+    mozilla-django-oidc >=1.0.0, <2.0.0
 tests_require =
     psycopg2
     pytest


### PR DESCRIPTION
mozilla-django-oidc-db is currently not compatible with mozilla-django-oidc 2.0.0. I'll look into what is needed to make them compatible (https://github.com/maykinmedia/mozilla-django-oidc-db/issues/16)