### PR TITLE
:sparkles: Configurable which endpoints must be derived from discovery

### DIFF
--- a/tests/test_admin_form.py
+++ b/tests/test_admin_form.py
@@ -56,6 +56,49 @@ def test_derive_endpoints_success():
     )
 
 
+@pytest.mark.django_db
+def test_derive_endpoints_extra_field():
+    form_data = {
+        "oidc_rp_client_id": "clientid",
+        "oidc_rp_client_secret": "secret",
+        "oidc_rp_sign_algo": "RS256",
+        "oidc_op_discovery_endpoint": "http://discovery-endpoint.nl/",
+        "claim_mapping": get_claim_mapping(),
+        "groups_claim": "roles",
+    }
+
+    class ExtendedOpenIDConnectConfigForm(OpenIDConnectConfigForm):
+        required_endpoints = OpenIDConnectConfigForm.required_endpoints
+        # Define an extra field to derive from the configuration
+        oidc_mapping = dict(
+            **OpenIDConnectConfigForm.oidc_mapping,
+            **{"logout_endpoint": "end_session_endpoint"}
+        )
+
+    form = ExtendedOpenIDConnectConfigForm(data=form_data)
+
+    configuration = {
+        "authorization_endpoint": "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
+        "token_endpoint": "http://provider.com/auth/realms/master/protocol/openid-connect/token",
+        "userinfo_endpoint": "http://provider.com/auth/realms/master/protocol/openid-connect/userinfo",
+        "jwks_uri": "http://provider.com/auth/realms/master/protocol/openid-connect/certs",
+        "end_session_endpoint": "http://provider.com/auth/realms/master/protocol/openid-connect/logout",
+    }
+    with requests_mock.Mocker() as m:
+        m.get(
+            "http://discovery-endpoint.nl/.well-known/openid-configuration",
+            json=configuration,
+        )
+        assert form.is_valid()
+
+    # The endpoint that was added to the mapping on the extended form
+    # should be present in the cleaned data
+    assert (
+        form.cleaned_data["logout_endpoint"]
+        == "http://provider.com/auth/realms/master/protocol/openid-connect/logout"
+    )
+
+
 @patch("requests.get", side_effect=RequestException)
 def test_derive_endpoints_request_error(*m):
     form_data = {


### PR DESCRIPTION
to make it easier to derive endpoints for an OpenIDConnectConfig model with extra fields/endpoints (see: https://github.com/open-formulieren/open-forms/pull/592/commits/72cda232de4e2d9c0f35e706d4c06eb06a63e372#diff-38ed140508dc1f213bac16db8a31499120023506309c0764358ac26cc8771a2aR22)