### PR TITLE
Feature/customizable cache prefix

### DIFF
--- a/mozilla_django_oidc_db/compat.py
+++ b/mozilla_django_oidc_db/compat.py
@@ -1,0 +1,6 @@
+# `classproperty` was moved to another module in Django 3.1
+# See https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/docs/releases/3.1.txt#L649
+try:
+    from django.utils.functional import classproperty
+except ImportError:
+    from django.utils.decorators import classproperty

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -63,3 +63,5 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "mozilla_django_oidc_db.backends.OIDCAuthenticationBackend",
 ]
+
+MOZILLA_DJANGO_OIDC_DB_PREFIX = "default"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mozilla_django_oidc_db.models import OpenIDConnectConfig, classproperty
+
+
+def test_default_cache_key():
+    assert OpenIDConnectConfig.get_cache_key() == "oidc:openidconnectconfig"
+
+
+def test_override_cache_key_with_class():
+    class CustomConfig(OpenIDConnectConfig):
+        class Meta:
+            app_label = "custom"
+
+        @classproperty
+        def custom_oidc_db_prefix(cls):
+            return "custom"
+
+    assert CustomConfig.get_cache_key() == "custom:customconfig"
+
+
+def test_custom_config_override_cache_key_with_settings():
+    class CustomConfig(OpenIDConnectConfig):
+        class Meta:
+            app_label = "custom"
+
+        @classproperty
+        def custom_oidc_db_prefix(cls):
+            return ""
+
+    # Prefix taken from `testapp/settings.py`
+    assert CustomConfig.get_cache_key() == "default:customconfig"
+
+
+@pytest.fixture()
+def unset_oidc_cache_prefix(settings):
+    del settings.MOZILLA_DJANGO_OIDC_DB_PREFIX
+
+
+def test_custom_config_cache_key_fallback(unset_oidc_cache_prefix):
+    class CustomConfig(OpenIDConnectConfig):
+        class Meta:
+            app_label = "custom"
+
+        @classproperty
+        def custom_oidc_db_prefix(cls):
+            return ""
+
+    # Prefix taken from `mozilla_django_oidc_dv/settings.py`
+    assert CustomConfig.get_cache_key() == "oidc:customconfig"


### PR DESCRIPTION
From https://github.com/open-formulieren/open-forms/pull/592#discussion_r806022212

Allows overriding of the SoloModel cache prefix for custom configs, without having to duplicate all the other cache code, by using the `CachingMixin`