### PR TITLE
:sparkles: Support extraction of nested configurable claims 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,28 @@ The name of the claim that is used for the ``User.username`` property
 can be configured via the admin. By default, the username is derived from the ``sub`` claim that
 is returned by the OIDC provider.
 
+If the desired claim is nested in one or more objects, its path can be specified with dots, e.g.:
+
+.. code-block:: json
+
+    {
+        "some": {
+            "nested": {
+                "claim": "foo"
+            }
+        }
+    }
+
+Can be retrieved by setting the username claim to ``some.nested.claim``
+
+**NOTE**: the username claim does not support claims that have dots in their name, it cannot be configured to retrieve the following claim for instance:
+
+.. code-block:: json
+
+    {
+        "some.dotted.claim": "foo"
+    }
+
 .. |build-status| image:: https://github.com/maykinmedia/mozilla-django-oidc-db/workflows/Run%20CI/badge.svg?branch=master
     :target: https://github.com/maykinmedia/mozilla-django-oidc-db/actions?query=workflow%3A%22Run+CI%22+branch%3Amaster
 

--- a/mozilla_django_oidc_db/backends.py
+++ b/mozilla_django_oidc_db/backends.py
@@ -41,6 +41,8 @@ class OIDCAuthenticationBackend(SoloConfigMixin, _OIDCAuthenticationBackend):
         # `OIDCAuthenticationBackend.__init__` is called for permission checks
 
     def retrieve_identifier_claim(self, claims: dict) -> str:
+        # NOTE: this does not support the extraction of claims that contain dots "." in
+        # their name (e.g. {"foo.bar": "baz"})
         identifier_claim_name = getattr(self.config, self.config_identifier_field)
         unique_id = glom(claims, identifier_claim_name, default="")
         return unique_id

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     django-better-admin-arrayfield
     django-solo
     mozilla-django-oidc >=1.0.0, <2.0.0
+    glom
 tests_require =
     psycopg2
     pytest


### PR DESCRIPTION
Issue: https://github.com/maykinmedia/mozilla-django-oidc-db/issues/42

- Add support for retrieval of nested claim values for user profile
- Add configurable `identifier_claim_name`

Might also be relevant for https://github.com/open-formulieren/open-forms/issues/1471

TODO:
- [x] Replace `username_claim` with `identifier_claim_name` like in OF?
- [x] Document issue with dotted claim names 