### PR TITLE
:sparkles: Obfuscate identifier claim before logging claims

### DIFF
--- a/mozilla_django_oidc_db/backends.py
+++ b/mozilla_django_oidc_db/backends.py
@@ -12,7 +12,7 @@ from mozilla_django_oidc.auth import (
 )
 
 from .mixins import SoloConfigMixin
-from .utils import obfuscate_claim
+from .utils import obfuscate_claims
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,15 @@ class OIDCAuthenticationBackend(SoloConfigMixin, _OIDCAuthenticationBackend):
 
     def get_sensitive_claims_names(self) -> list:
         """
-        Defines the claims that should be obfuscated before logging claims
+        Defines the claims that should be obfuscated before logging claims.
+        Nested claims can be specified by using a dotted path (e.g. "foo.bar.baz")
+
+        NOTE: this does not support claim names that have dots in them, so the following
+        claim cannot be marked as a sensitive claim
+
+            {
+                "foo.bar": "baz"
+            }
         """
         identifier_claim_name = getattr(self.config, self.config_identifier_field)
         return [identifier_claim_name] + self.sensitive_claim_names
@@ -96,14 +104,12 @@ class OIDCAuthenticationBackend(SoloConfigMixin, _OIDCAuthenticationBackend):
 
     def verify_claims(self, claims) -> bool:
         """Verify the provided claims to decide if authentication should be allowed."""
-        identifier_claim_name = getattr(self.config, self.config_identifier_field)
-        obfuscated_claims = {
-            k: obfuscate_claim(v) if k in self.get_sensitive_claims_names() else v
-            for k, v in claims.items()
-        }
+        claims_to_obfuscate = self.get_sensitive_claims_names()
+        obfuscated_claims = obfuscate_claims(claims, claims_to_obfuscate)
 
         logger.debug("OIDC claims received: %s", obfuscated_claims)
 
+        identifier_claim_name = getattr(self.config, self.config_identifier_field)
         if not glom(claims, identifier_claim_name, default=""):
             logger.error(
                 "%s not in OIDC claims, cannot proceed with authentication",

--- a/mozilla_django_oidc_db/utils.py
+++ b/mozilla_django_oidc_db/utils.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+
+def obfuscate_claim(value: Any) -> str:
+    """
+    Obfuscates the value of a claim, so it can be logged safely
+    """
+    value = str(value)
+    threshold = int(len(value) * 0.75)
+    return "".join([x if i > threshold else "*" for i, x in enumerate(value)])

--- a/mozilla_django_oidc_db/utils.py
+++ b/mozilla_django_oidc_db/utils.py
@@ -1,10 +1,29 @@
-from typing import Any
+from copy import deepcopy
+from typing import Any, List
+
+from glom import assign, glom
 
 
-def obfuscate_claim(value: Any) -> str:
+def obfuscate_claim_value(value: Any) -> str:
     """
     Obfuscates the value of a claim, so it can be logged safely
+
+    If a dict of claims is supplied, all of the values will be obfuscated
     """
-    value = str(value)
-    threshold = int(len(value) * 0.75)
-    return "".join([x if i > threshold else "*" for i, x in enumerate(value)])
+    if isinstance(value, dict):
+        for k, v in value.items():
+            value[k] = obfuscate_claim_value(v)
+        return value
+    else:
+        value = str(value)
+        threshold = int(len(value) * 0.75)
+        return "".join([x if i > threshold else "*" for i, x in enumerate(value)])
+
+
+def obfuscate_claims(claims: dict, claims_to_obfuscate: List[str]) -> dict:
+    copied_claims = deepcopy(claims)
+    for claim_name in claims_to_obfuscate:
+        # NOTE: this does not support claim names that have dots in them
+        claim_value = glom(copied_claims, claim_name)
+        assign(copied_claims, claim_name, obfuscate_claim_value(claim_value))
+    return copied_claims

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -24,6 +24,23 @@ def test_backend_authenticate_oidc_not_enabled(mock_get_solo):
 
 
 @patch("mozilla_django_oidc_db.models.OpenIDConnectConfig.get_solo")
+def test_backend_get_sensitive_claims(mock_get_solo):
+    mock_get_solo.return_value = OpenIDConnectConfig(enabled=True, username_claim="sub")
+
+    class CustomOIDCBackend(OIDCAuthenticationBackend):
+        sensitive_claim_names = ["sensitive_claim1", "sensitive_claim2"]
+
+    backend = CustomOIDCBackend()
+
+    # Only the sensitive claims + the identifier claim should be obfuscated
+    assert backend.get_sensitive_claims_names() == [
+        "sub",
+        "sensitive_claim1",
+        "sensitive_claim2",
+    ]
+
+
+@patch("mozilla_django_oidc_db.models.OpenIDConnectConfig.get_solo")
 def test_backend_get_user_instance_values(mock_get_solo):
     mock_get_solo.return_value = OpenIDConnectConfig(
         claim_mapping=OpenIDConnectConfig._meta.get_field("claim_mapping").get_default()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,41 @@
-from mozilla_django_oidc_db.utils import obfuscate_claim
+from mozilla_django_oidc_db.utils import obfuscate_claim_value, obfuscate_claims
 
 
 def test_obfuscate_string():
     value = "123456782"
-    result = obfuscate_claim(value)
+    result = obfuscate_claim_value(value)
 
     assert result == "*******82"
 
 
 def test_obfuscate_non_string():
     value = 12345
-    result = obfuscate_claim(value)
+    result = obfuscate_claim_value(value)
 
     assert result == "****5"
+
+
+def test_obfuscate_nested():
+    claims = {
+        "foo": "not_obfuscated",
+        "some": {
+            "nested": {
+                "claim": "obfuscated",
+                "claim2": "not_obfuscated",
+            }
+        },
+        "object": {
+            "foo": "obfuscated",
+            "bar": "obfuscated",
+        },
+    }
+    claims_to_obfuscate = ["some.nested.claim", "object"]
+    expected_result = {
+        "foo": "not_obfuscated",
+        "some": {"nested": {"claim": "********ed", "claim2": "not_obfuscated"}},
+        "object": {"foo": "********ed", "bar": "********ed"},
+    }
+
+    result = obfuscate_claims(claims, claims_to_obfuscate)
+
+    assert result == expected_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from mozilla_django_oidc_db.utils import obfuscate_claim
+
+
+def test_obfuscate_string():
+    value = "123456782"
+    result = obfuscate_claim(value)
+
+    assert result == "*******82"
+
+
+def test_obfuscate_non_string():
+    value = 12345
+    result = obfuscate_claim(value)
+
+    assert result == "****5"


### PR DESCRIPTION
Issue: #42

Changes
- Add configurable sensitive claims on backend, that will be obfuscated before logging them

TODO:
- [x] Implement for nested claims