### PR TITLE
Feature/release 0.13.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 0.12.0
+current_version = 0.13.0
 
 [bumpversion:file:setup.cfg]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.13.0 (2023-12-21)
+===================
+
+* [`#65`_] Add functionality to make users superuser based on groups
+* [`#68`_] More clear label/helptext for sync_groups
+
+.. _#65: https://github.com/maykinmedia/mozilla-django-oidc-db/issues/65
+.. _#68: https://github.com/maykinmedia/mozilla-django-oidc-db/issues/68
+
 0.12.0 (2022-12-14)
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 Welcome to mozilla_django_oidc_db's documentation!
 ==================================================
 
-:Version: 0.12.0
+:Version: 0.13.0
 :Source: https://github.com/maykinmedia/mozilla-django-oidc-db
 :Keywords: OIDC, django, database, authentication
 :PythonVersion: 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # see http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = mozilla-django-oidc-db
-version = 0.12.0
+version = 0.13.0
 description = A database-backed configuration for mozilla-django-oidc
 long_description = file: README.rst
 url = https://github.com/maykinmedia/mozilla-django-oidc-db


### PR DESCRIPTION
Skipping the changes introduced in https://github.com/maykinmedia/mozilla-django-oidc-db/pull/64 for this release to avoid a major version release. I based tag `0.13.0` on `0.12.0` and cherry picked the changes