### PR TITLE
:sparkles: Replace django-better-admin-arrayfield with django-jsonform

### DIFF
--- a/mozilla_django_oidc_db/admin.py
+++ b/mozilla_django_oidc_db/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
-from django_better_admin_arrayfield.admin.mixins import DynamicArrayMixin
 from solo.admin import SingletonModelAdmin
 
 from .forms import OpenIDConnectConfigForm
@@ -9,7 +8,7 @@ from .models import OpenIDConnectConfig
 
 
 @admin.register(OpenIDConnectConfig)
-class OpenIDConnectConfigAdmin(DynamicArrayMixin, SingletonModelAdmin):
+class OpenIDConnectConfigAdmin(SingletonModelAdmin):
     form = OpenIDConnectConfigForm
     fieldsets = (
         (

--- a/mozilla_django_oidc_db/apps.py
+++ b/mozilla_django_oidc_db/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class MozillaDjangoOidcDbConfig(AppConfig):
     name = "mozilla_django_oidc_db"
+    default_auto_field = "django.db.models.AutoField"

--- a/mozilla_django_oidc_db/migrations/0001_initial.py
+++ b/mozilla_django_oidc_db/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-import django_better_admin_arrayfield.models.fields
+import django_jsonform.models.fields
 
 import mozilla_django_oidc_db.models
 
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_rp_scopes_list",
-                    django_better_admin_arrayfield.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(
                         base_field=models.CharField(
                             max_length=50, verbose_name="OpenID Connect scope"
                         ),

--- a/mozilla_django_oidc_db/migrations/0007_auto_20220307_1128.py
+++ b/mozilla_django_oidc_db/migrations/0007_auto_20220307_1128.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-import django_better_admin_arrayfield.models.fields
+import django_jsonform.models.fields
 
 
 class Migration(migrations.Migration):
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="openidconnectconfig",
             name="oidc_exempt_urls",
-            field=django_better_admin_arrayfield.models.fields.ArrayField(
+            field=django_jsonform.models.fields.ArrayField(
                 base_field=models.CharField(max_length=1000, verbose_name="Exempt URL"),
                 blank=True,
                 default=list,

--- a/mozilla_django_oidc_db/migrations/0012_openidconnectconfig_superuser_group_names.py
+++ b/mozilla_django_oidc_db/migrations/0012_openidconnectconfig_superuser_group_names.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-import django_better_admin_arrayfield.models.fields
+import django_jsonform.models.fields
 
 
 class Migration(migrations.Migration):
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="openidconnectconfig",
             name="superuser_group_names",
-            field=django_better_admin_arrayfield.models.fields.ArrayField(
+            field=django_jsonform.models.fields.ArrayField(
                 base_field=models.CharField(
                     max_length=50, verbose_name="Superuser group name"
                 ),

--- a/mozilla_django_oidc_db/models.py
+++ b/mozilla_django_oidc_db/models.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from django_better_admin_arrayfield.models.fields import ArrayField
+from django_jsonform.models.fields import ArrayField
 from solo.models import SingletonModel, get_cache
 
 import mozilla_django_oidc_db.settings as oidc_settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 packages = find:
 install_requires =
     Django >=3.2
-    django-better-admin-arrayfield
+    django-jsonform
     django-solo
     glom
     mozilla-django-oidc >=2.0.0

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.admin",
     "solo",
-    "django_better_admin_arrayfield",
+    "django_jsonform",
     "mozilla_django_oidc",
     "mozilla_django_oidc_db",
     "testapp",


### PR DESCRIPTION
The former does not properly work on Django 4.1+.