### PR TITLE
:boom: Drop support for older versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
-        django: ['3.2', '4.1', '4.2']
-        mozilla_django_oidc: ['2.0', '3.0']
+        python: ['3.10', '3.11', '3.12']
+        django: ['3.2', '4.2']
+        mozilla_django_oidc: ['3.0', '4.0']
         exclude:
-          - django: ['4.1', '4.2']
-            mozilla_django_oidc: '2.0'
           - python: '3.11'
             django: '3.2'
+          - python: '3.12'
+            django: '3.2'
+          # support for django 4.2 was added in 4.0
+          - django: '4.2'
+            mozilla_django_oidc: '3.0'
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }}, mozilla-django-oidc ${{ matrix.mozilla_django_oidc }})
 
@@ -37,8 +40,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -65,10 +68,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Build sdist and wheel
         run: |

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         toxenv: [isort, black]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: pip install tox
       - run: tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog
 =========
 
+0.15.0 (unreleased)
+===================
+
+**Breaking changes**
+
+* Dropped support for Django 4.1
+* Dropped support for Python 3.8 and 3.9
+* Dropped support for mozilla-django-oidc 2.0
+
+**New features**
+
+* Confirmed support for mozilla-django-oidc 4.0
+* Confirmed support for Python 3.12
+* Added more typehints
+* ...
+
 0.14.1 (2024-01-12)
 ===================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.rst
 include LICENSE
+include mozilla_django_oidc_db/py.typed
 recursive-include mozilla_django_oidc_db *.html
 recursive-include mozilla_django_oidc_db *.txt
 recursive-include mozilla_django_oidc_db *.po

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,6 @@ Welcome to mozilla_django_oidc_db's documentation!
 :Version: 0.14.1
 :Source: https://github.com/maykinmedia/mozilla-django-oidc-db
 :Keywords: OIDC, django, database, authentication
-:PythonVersion: 3.7
 
 |build-status| |coverage| |black|
 
@@ -44,13 +43,8 @@ Installation
 Requirements
 ------------
 
-* Python 3.7 or above
-* setuptools 30.4.0 or above
-* Django 3.2 or newer
-* A database supporting ``models.JSONField``
-* If you're using Django 4.1 or newer, you need at least mozilla-django-oidc 3.0.
-  2.0 is still supported with Django 3.2.
-
+* See the badges for the supported Python and Django versions
+* A PostgreSQL database (we use ``django.contrib.postgres.fields.ArrayField``)
 
 Install
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,28 +14,27 @@ classifiers =
     Development Status :: 4 - Beta
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
+python_requires = >=3.10
 install_requires =
     Django >=3.2
     django-jsonform
     django-solo
     glom
-    mozilla-django-oidc >=2.0.0
+    mozilla-django-oidc >=3.0.0
 tests_require =
     psycopg2
     pytest
@@ -77,14 +76,9 @@ release =
 test=pytest
 
 [isort]
+profile = black
 combine_as_imports = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-line_length = 88
-multi_line_output = 3
-skip = env,.tox,.history,.eggs
-; skip_glob =
-known_django=django
+known_django = django
 known_first_party=mozilla_django_oidc_db
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{38,39,310}-django32-mozilla_django_oidc{20}
-    py{38,39,310,311}-django{41,42}-mozilla_django_oidc{30}
+    py310-django32-mozilla_django_oidc{30,40}
+    py{310,311,312}-django42-mozilla_django_oidc40
     isort
     black
     ; docs
@@ -13,25 +13,24 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =
     3.2: django32
-    4.1: django41
     4.2: django42
 MOZILLA_DJANGO_OIDC =
-    2.0: mozilla_django_oidc20
     3.0: mozilla_django_oidc30
+    4.0: mozilla_django_oidc40
 [testenv]
 extras =
     tests
     coverage
 deps =
   django32: Django~=3.2.0
-  django41: Django~=4.1.0
   django42: Django~=4.2.0
-  mozilla_django_oidc20: mozilla-django-oidc~=2.0.0
   mozilla_django_oidc30: mozilla-django-oidc~=3.0.0
+  mozilla_django_oidc40: mozilla-django-oidc~=4.0.0
 passenv =
     PGUSER
     PGDATABASE


### PR DESCRIPTION
* Dropped support for python older than 3.10
* Drop support for mozilla-django-oidc older than 3.0
* Drop support for non-maintained Django versions
* Updated CI actions to non-deprecated versions
* Added typing marker to project