### PR TITLE
:bug: Fix obfuscation of missing claims

### DIFF
--- a/mozilla_django_oidc_db/backends.py
+++ b/mozilla_django_oidc_db/backends.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 from collections.abc import Collection
-from typing import Any, TypeAlias, TypeVar, cast
+from typing import Any, TypeAlias, cast
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import (
@@ -23,19 +23,13 @@ from typing_extensions import override
 from .config import dynamic_setting, get_setting_from_config, lookup_config
 from .exceptions import MissingIdentifierClaim
 from .jwt import verify_and_decode_token
-from .models import (
-    OpenIDConnectConfig,
-    OpenIDConnectConfigBase,
-    UserInformationClaimsSources,
-)
+from .models import OpenIDConnectConfigBase, UserInformationClaimsSources
 from .typing import ClaimPath, JSONObject
 from .utils import extract_content_type, obfuscate_claims
 
 logger = logging.getLogger(__name__)
 
 AnyUser: TypeAlias = AnonymousUser | AbstractBaseUser
-
-T = TypeVar("T", bound=OpenIDConnectConfig)
 
 missing = object()
 

--- a/mozilla_django_oidc_db/utils.py
+++ b/mozilla_django_oidc_db/utils.py
@@ -1,7 +1,7 @@
 from collections.abc import Collection
 from copy import deepcopy
 
-from glom import Path, assign, glom
+from glom import Path, PathAccessError, assign, glom
 from requests.utils import _parse_content_type_header  # type: ignore
 
 from .typing import ClaimPath, JSONObject, JSONValue
@@ -32,7 +32,10 @@ def obfuscate_claims(
     copied_claims = deepcopy(claims)
     for claim_bits in claims_to_obfuscate:
         claim_path = Path(*claim_bits)
-        claim_value = glom(copied_claims, claim_path)
+        try:
+            claim_value = glom(copied_claims, claim_path)
+        except PathAccessError:
+            continue
         assign(copied_claims, claim_path, obfuscate_claim_value(claim_value))
     return copied_claims
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -657,11 +657,11 @@ def test_init_does_not_perform_config_io(mocker):
     * pytest will complain about database access which is forbidden because there is
       no pytest.mark.django_db present (deliberately)
     """
-    m_get_solo = mocker.patch(
-        "mozilla_django_oidc_db.backends.OpenIDConnectConfig.get_solo"
+    m_get_setting = mocker.patch(
+        "mozilla_django_oidc_db.backends.get_setting_from_config"
     )
 
     # instantiate
     OIDCAuthenticationBackend()
 
-    m_get_solo.assert_not_called()
+    m_get_setting.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from mozilla_django_oidc_db.typing import JSONObject
 from mozilla_django_oidc_db.utils import obfuscate_claim_value, obfuscate_claims
 
 
@@ -45,3 +46,11 @@ def test_obfuscate_nested():
     result = obfuscate_claims(claims, claims_to_obfuscate)
 
     assert result == expected_result
+
+
+def test_obfuscate_with_missing_claims():
+    claims: JSONObject = {"present": "12345"}
+
+    result = obfuscate_claims(claims, claims_to_obfuscate=(["missing"], ["present"]))
+
+    assert result == {"present": "****5"}


### PR DESCRIPTION
The obfuscation helper was crashing on missing/absent claims that should be obfuscated.