### PR TITLE
Type check the package in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.12', '3.13']
         django: ['4.2', '5.2']
         mozilla_django_oidc: ['4.0']
         setup_config_enabled: ['no', 'yes']

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toxenv: [ruff, docs]
+        toxenv: [ruff, docs, typecheck]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,9 +8,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: 'ubuntu-22.04'
+  os: 'ubuntu-24.04'
   tools:
-    python: '3.10'
+    python: '3.12'
 
 python:
   install:

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -18,9 +18,12 @@ We offer flexibility through a generic configuration mechanism.
 .. versionadded:: 0.17.0
     The generic configuration mechanism was added.
 
-.. versionadded:: 0.24.0
+.. versionchanged:: 0.24.0
     The models were refactored to no longer be solo-models.
 
+.. versionchanged:: 0.26.0
+    The type definitions and annotations were overhauled for correctness and
+    completeness.
 
 Models
 ======
@@ -28,23 +31,27 @@ Models
 We provide a model :class:`~mozilla_django_oidc_db.models.OIDCClient`.
 
 This makes some of the upstream library settings dynamic rather than having to specify
-them as Django settings. The :class:`~mozilla_django_oidc_db.models.OIDCClient` has a JSON field ``options`` that can be used
-to specify any configuration that is specific to an OIDC Identity Provider.
-The structure of this field is specified with a JSON schema and thanks to ``django-jsonform`` the admin displays a nice
-form for it instead of a plain text field.
+them as Django settings. The :class:`~mozilla_django_oidc_db.models.OIDCClient` has a
+JSON field ``options`` that can be used to specify any configuration that is specific to
+an OIDC Identity Provider. The structure of this field is specified with a JSON schema
+and thanks to ``django-jsonform`` the admin displays a nice form for it instead of a
+plain text field.
 
-If you want to bring your own configuration, you should create a new :class:`~mozilla_django_oidc_db.models.OIDCClient`
-and a corresponding plugin that should implement the interface specified by either the 
-:class:`~mozilla_django_oidc_db.plugins.AnonymousUserOIDCPluginProtocol` or the :class:`~mozilla_django_oidc_db.plugins.AbstractUserOIDCPluginProtocol`.
-The plugin should be registered with the same identifier as the corresponding :class:`~mozilla_django_oidc_db.models.OIDCClient`.
-You can inherit from the :class:`~mozilla_django_oidc_db.plugins.BaseOIDCPlugin` to inherit some
-of the base plugin behaviour.
+If you want to bring your own configuration, you should create a new
+:class:`~mozilla_django_oidc_db.models.OIDCClient`
+and a corresponding plugin that should inherit from either either
+:class:`~mozilla_django_oidc_db.plugins.AnonymousUserOIDCPlugin` or
+:class:`~mozilla_django_oidc_db.plugins.AbstractUserOIDCPlugin`.
+
+The plugin should be registered with the same identifier as the corresponding
+:class:`~mozilla_django_oidc_db.models.OIDCClient`.
 
 
 Plugin
 ======
 
-We use a plugin architecture to encapsulate any behaviour specific to a particular OIDC provider or Identity Provider.
+We use a plugin architecture to encapsulate any behaviour specific to a particular OIDC
+provider or Identity Provider.
 
 A custom plugin can be registered as follows:
 
@@ -53,20 +60,24 @@ A custom plugin can be registered as follows:
     from mozilla_django_oidc_db.registry import register
 
     @register("oidc-custom-identifier")
-    class OIDCCustomPlugin(AbstractUserOIDCPluginProtocol):
+    class OIDCCustomPlugin(AbstractUserOIDCPlugin):
         ...
 
-The protocol :class:`~mozilla_django_oidc_db.plugins.OIDCBasePluginProtocol` specifies the functionality that all plugins
-should implement, while the :class:`~mozilla_django_oidc_db.plugins.AnonymousUserOIDCPluginProtocol` and 
-:class:`~mozilla_django_oidc_db.plugins.AbstractUserOIDCPluginProtocol` specify additional methods that should be implemented 
-depending on whether Django users should be created when a user logs in with OIDC or not.
+The abstract base class :class:`~mozilla_django_oidc_db.plugins.BaseOIDCPlugin` specifies
+the functionality that all plugins must implement, while the
+:class:`~mozilla_django_oidc_db.plugins.AnonymousUserOIDCPlugin` and
+:class:`~mozilla_django_oidc_db.plugins.AbstractUserOIDCPlugin` specify additional methods
+that should be implemented depending on whether Django users should be created when a
+user logs in with OIDC or not.
 
-At start-up, a signal will run after the migrations to create an ``OIDCClient`` (if it doesn't already exist) for every plugin
-registered.
+At start-up, a signal will run after the migrations to create an ``OIDCClient`` record
+(if it doesn't already exist) for every plugin registered, keeping code and database
+configuration in sync.
 
-The :class:`~mozilla_django_oidc_db.views.OIDCCallbackView` and the :class:`~mozilla_django_oidc_db.backends.OIDCAuthenticationBackend`
-both rely on the plugins. This should make it possible to implement all custom behaviour in the plugins without 
-having to override the callback view and the backend.
+The :class:`~mozilla_django_oidc_db.views.OIDCCallbackView` and the
+:class:`~mozilla_django_oidc_db.backends.OIDCAuthenticationBackend` both rely on the
+plugins. This should make it possible to implement all custom behaviour in the plugins
+without having to override the callback view and the backend.
 
 
 OIDC flow initialization
@@ -75,10 +86,10 @@ OIDC flow initialization
 Typically when a user needs to authenticate, they click a button or link to do so. This
 navigation is tied to a particular URL path, for example ``/auth/oidc-custom/``.
 
-We provide :class:`~mozilla_django_oidc_db.views.OIDCAuthenticationRequestInitView` to start an OIDC authentication flow.
-This view class is parametrized with the identifier of the config model, so that
-the specific configuration can be retrieved and settings such as the identity provider endpoint
-to redirect the user to can be obtained.
+We provide :class:`~mozilla_django_oidc_db.views.OIDCAuthenticationRequestInitView` to
+start an OIDC authentication flow. This view class is parametrized with the identifier
+of the config model, so that the specific configuration can be retrieved and settings
+such as the identity provider endpoint to redirect the user to can be obtained.
 
 This view is not necessarily meant to be exposed directly via a URL pattern, but
 rather specific views are to be created from it, e.g.:

--- a/mozilla_django_oidc_db/backends.py
+++ b/mozilla_django_oidc_db/backends.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import (
@@ -14,7 +14,6 @@ from django.http import HttpRequest
 
 import requests
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend as BaseBackend
-from typing_extensions import override
 
 from .config import dynamic_setting, lookup_config
 from .exceptions import MissingInitialisation

--- a/mozilla_django_oidc_db/backends.py
+++ b/mozilla_django_oidc_db/backends.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast, override
+from typing import Any, override
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import (
@@ -19,10 +19,7 @@ from .config import dynamic_setting, lookup_config
 from .exceptions import MissingInitialisation
 from .jwt import verify_and_decode_token
 from .models import OIDCClient, UserInformationClaimsSources
-from .plugins import (
-    AbstractUserOIDCPluginProtocol,
-    AnonymousUserOIDCPluginProtocol,
-)
+from .plugins import AbstractUserOIDCPlugin, AnonymousUserOIDCPlugin
 from .registry import register as registry
 from .typing import JSONObject
 from .utils import extract_content_type
@@ -75,10 +72,12 @@ class OIDCAuthenticationBackend(BaseBackend):
 
         # django-stubs returns AbstractBaseUser, but we depend on properties of
         # AbstractUser.
-        self.UserModel = cast(AbstractUser, get_user_model())
+        UserModel = get_user_model()
+        assert issubclass(UserModel, AbstractUser)
+        self.UserModel = UserModel
 
     @override
-    def get_settings(self, attr: str, *args: Any) -> Any:  # type: ignore
+    def get_settings(self, attr: str, *args: Any) -> Any:  # pyright: ignore[reportIncompatibleMethodOverride]
         """
         Override the upstream library get_settings.
 
@@ -106,7 +105,7 @@ class OIDCAuthenticationBackend(BaseBackend):
     # `OIDCAuthenticationCallbackView` for the `auth.authenticate(**kwargs)` call if this
     # needs updating.
     @override
-    def authenticate(  # type: ignore
+    def authenticate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         request: HttpRequest | None,
         nonce: str | None = None,
@@ -138,7 +137,7 @@ class OIDCAuthenticationBackend(BaseBackend):
         # Store the config class identifier on the user, so that we can store this in the user's
         # session after they have been successfully authenticated (by listening to the `user_logged_in` signal)
         if user:
-            user._oidcdb_config_identifier = self.config.identifier  # type: ignore
+            user._oidcdb_config_identifier = self.config.identifier  # pyright: ignore[reportAttributeAccessIssue]
 
         return user
 
@@ -149,7 +148,7 @@ class OIDCAuthenticationBackend(BaseBackend):
         assert self.config
 
         plugin = registry[self.config.identifier]
-        assert isinstance(plugin, AbstractUserOIDCPluginProtocol)
+        assert isinstance(plugin, AbstractUserOIDCPlugin)
         return plugin.verify_claims(claims)
 
     @override
@@ -214,11 +213,11 @@ class OIDCAuthenticationBackend(BaseBackend):
     @override
     def filter_users_by_claims(
         self, claims: JSONObject
-    ) -> models.Manager[AbstractUser]:  # type: ignore (parent function returns UserManager which is more specific than Manager)
+    ) -> models.QuerySet[AbstractUser]:
         assert self.config
         plugin = registry[self.config.identifier]
 
-        assert isinstance(plugin, AbstractUserOIDCPluginProtocol)
+        assert isinstance(plugin, AbstractUserOIDCPlugin)
         return plugin.filter_users_by_claims(claims)
 
     @override
@@ -227,7 +226,7 @@ class OIDCAuthenticationBackend(BaseBackend):
         assert self.config
         plugin = registry[self.config.identifier]
 
-        assert isinstance(plugin, AbstractUserOIDCPluginProtocol)
+        assert isinstance(plugin, AbstractUserOIDCPlugin)
         return plugin.create_user(claims)
 
     @override
@@ -235,22 +234,27 @@ class OIDCAuthenticationBackend(BaseBackend):
         assert self.config
         plugin = registry[self.config.identifier]
 
-        assert isinstance(plugin, AbstractUserOIDCPluginProtocol)
+        assert isinstance(plugin, AbstractUserOIDCPlugin)
         return plugin.update_user(user, claims)
 
     @override
     def get_or_create_user(
         self, access_token: str, id_token: str, payload: JSONObject
-    ) -> AnonymousUser | AbstractUser | None:  # type: ignore (parent function returns only an AbstractUser | None)
+    ) -> AnonymousUser | AbstractUser | None:
         """Get or create a user based on the tokens received."""
         assert self.config
 
         plugin = registry[self.config.identifier]
         assert isinstance(self.request, HttpRequest)
 
-        if isinstance(plugin, AnonymousUserOIDCPluginProtocol):
+        # shortcut for "anonymous users" where the OIDC authentication *does* happen,
+        # but no actual Django user instance is created.
+        if isinstance(plugin, AnonymousUserOIDCPlugin):
             return plugin.get_or_create_user(
                 access_token, id_token, payload, self.request
             )
 
-        return super().get_or_create_user(access_token, id_token, payload)
+        user = super().get_or_create_user(access_token, id_token, payload)
+        if user is not None:
+            assert isinstance(user, self.UserModel)
+        return user

--- a/mozilla_django_oidc_db/config.py
+++ b/mozilla_django_oidc_db/config.py
@@ -6,7 +6,7 @@ configuration model instance rather than in Django settings, while also handling
 settings that are still defined in the django settings layer.
 """
 
-from typing import Any, Generic, Protocol, TypeVar, overload
+from typing import Any, Generic, Protocol, Self, TypeVar, Unpack, overload
 
 from django.core.exceptions import (
     BadRequest,
@@ -14,7 +14,7 @@ from django.core.exceptions import (
 from django.http import HttpRequest
 
 from mozilla_django_oidc.utils import import_from_settings
-from typing_extensions import Self, TypedDict, Unpack
+from typing_extensions import TypedDict
 
 from .constants import CONFIG_IDENTIFIER_SESSION_KEY
 from .models import OIDCClient
@@ -74,7 +74,7 @@ class DynamicSettingKwargs(TypedDict, Generic[T], total=False):
     default: T
 
 
-class dynamic_setting(Generic[T]):
+class dynamic_setting[T]:
     """
     Descriptor to lazily access settings while explicitly defining them.
 

--- a/mozilla_django_oidc_db/config.py
+++ b/mozilla_django_oidc_db/config.py
@@ -6,7 +6,7 @@ configuration model instance rather than in Django settings, while also handling
 settings that are still defined in the django settings layer.
 """
 
-from typing import Any, Generic, Protocol, Self, TypeVar, Unpack, overload
+from typing import Any, Protocol, Self, TypeVar, Unpack, overload
 
 from django.core.exceptions import (
     BadRequest,
@@ -70,7 +70,7 @@ class SettingsHolder(Protocol[T]):
     def get_settings(self, attr: str, *args: T) -> T: ...
 
 
-class DynamicSettingKwargs(TypedDict, Generic[T], total=False):
+class DynamicSettingKwargs[T](TypedDict, total=False):
     default: T
 
 

--- a/mozilla_django_oidc_db/constants.py
+++ b/mozilla_django_oidc_db/constants.py
@@ -1,6 +1,10 @@
+from collections.abc import Mapping
+
+from .typing import EndpointFieldNames
+
 # Mapping the configuration model fieldnames for endpoints to their
 # corresponding names in the OIDC spec
-OIDC_MAPPING = {
+OIDC_MAPPING: Mapping[EndpointFieldNames, str] = {
     "oidc_op_authorization_endpoint": "authorization_endpoint",
     "oidc_op_token_endpoint": "token_endpoint",
     "oidc_op_user_endpoint": "userinfo_endpoint",

--- a/mozilla_django_oidc_db/forms.py
+++ b/mozilla_django_oidc_db/forms.py
@@ -56,15 +56,15 @@ class OIDCProviderForm(forms.ModelForm):
         return endpoints
 
     def clean(self):
-        cleaned_data = super().clean()
+        super().clean()
 
-        discovery_endpoint = cleaned_data.get("oidc_op_discovery_endpoint")
+        discovery_endpoint = self.cleaned_data.get("oidc_op_discovery_endpoint")
 
         # Derive the endpoints from the discovery endpoint
         if discovery_endpoint:
             try:
                 endpoints = self.get_endpoints_from_discovery(discovery_endpoint)
-                cleaned_data.update(**endpoints)
+                self.cleaned_data.update(**endpoints)
             except (
                 requests.exceptions.RequestException,
                 json.decoder.JSONDecodeError,
@@ -80,7 +80,7 @@ class OIDCProviderForm(forms.ModelForm):
             # Verify that the required endpoints were derived from the
             # discovery endpoint
             for field in self.required_endpoints:
-                if not cleaned_data.get(field):
+                if not self.cleaned_data.get(field):
                     self.add_error(field, _("This field is required."))
 
-        return cleaned_data
+        return self.cleaned_data

--- a/mozilla_django_oidc_db/forms.py
+++ b/mozilla_django_oidc_db/forms.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
@@ -7,6 +8,9 @@ import requests
 
 from .constants import OIDC_MAPPING, OPEN_ID_CONFIG_PATH
 from .models import OIDCProvider
+from .typing import EndpointFieldNames
+
+type EndpointsMapping = Mapping[EndpointFieldNames, str]
 
 
 class OIDCProviderForm(forms.ModelForm):
@@ -44,12 +48,12 @@ class OIDCProviderForm(forms.ModelForm):
                 self.fields[endpoint].required = False
 
     @classmethod
-    def get_endpoints_from_discovery(cls, base_url: str):
+    def get_endpoints_from_discovery(cls, base_url: str) -> EndpointsMapping:
         response = requests.get(f"{base_url}{OPEN_ID_CONFIG_PATH}", timeout=10)
         response.raise_for_status()
         configuration = response.json()
 
-        endpoints = {
+        endpoints: EndpointsMapping = {
             model_attr: configuration.get(oidc_attr)
             for model_attr, oidc_attr in cls.oidc_mapping.items()
         }

--- a/mozilla_django_oidc_db/middleware.py
+++ b/mozilla_django_oidc_db/middleware.py
@@ -1,9 +1,8 @@
-from typing import Any
+from typing import Any, override
 
 from django.urls import reverse
 
 from mozilla_django_oidc.middleware import SessionRefresh as BaseSessionRefresh
-from typing_extensions import override
 
 from .config import (
     BadRequest,

--- a/mozilla_django_oidc_db/middleware.py
+++ b/mozilla_django_oidc_db/middleware.py
@@ -67,8 +67,11 @@ class SessionRefresh(BaseSessionRefresh):
 
         return super().process_request(request)
 
+    # we can't use cached_property, because a middleware instance exists for the whole
+    # duration of the django server life cycle, and the relevant config can change
+    # between requests. See ``process_request``.
     @property
-    def exempt_urls(self):
+    def exempt_urls(self):  # pyright: ignore[reportIncompatibleVariableOverride]
         # In many cases, the OIDC_AUTHENTICATION_CALLBACK_URL will be the generic
         # callback handler and already be part of super().exempt_urls. However, this is
         # not a given, and consumers might have implemented different callback handlers,

--- a/mozilla_django_oidc_db/migrations/0001_initial_to_v015.py
+++ b/mozilla_django_oidc_db/migrations/0001_initial_to_v015.py
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_rp_scopes_list",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="OpenID Connect scope"
                         ),
@@ -176,7 +176,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_exempt_urls",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=1000, verbose_name="Exempt URL"
                         ),
@@ -235,7 +235,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "superuser_group_names",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="Superuser group name"
                         ),

--- a/mozilla_django_oidc_db/migrations/0001_initial_to_v023.py
+++ b/mozilla_django_oidc_db/migrations/0001_initial_to_v023.py
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_rp_scopes_list",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="OpenID Connect scope"
                         ),
@@ -215,7 +215,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "superuser_group_names",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="Superuser group name"
                         ),

--- a/mozilla_django_oidc_db/migrations/0002_migrate_to_claim_field.py
+++ b/mozilla_django_oidc_db/migrations/0002_migrate_to_claim_field.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="openidconnectconfig",
             name="new_groups_claim",
-            field=mozilla_django_oidc_db.fields.ClaimField(
+            field=mozilla_django_oidc_db.fields.ClaimField(  # type: ignore
                 base_field=models.CharField(
                     max_length=50, verbose_name="claim path segment"
                 ),
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="openidconnectconfig",
             name="new_username_claim",
-            field=mozilla_django_oidc_db.fields.ClaimField(
+            field=mozilla_django_oidc_db.fields.ClaimField(  # type: ignore
                 base_field=models.CharField(
                     max_length=50, verbose_name="claim path segment"
                 ),

--- a/mozilla_django_oidc_db/migrations/0006_oidcprovider_oidcclient.py
+++ b/mozilla_django_oidc_db/migrations/0006_oidcprovider_oidcclient.py
@@ -175,7 +175,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_rp_scopes_list",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="Scope"
                         ),

--- a/mozilla_django_oidc_db/plugins.py
+++ b/mozilla_django_oidc_db/plugins.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser, AnonymousUser
@@ -109,7 +109,7 @@ class AbstractUserOIDCPluginProtocol(OIDCBasePluginProtocol, Protocol):
         ...
 
 
-OIDCPlugin: TypeAlias = AbstractUserOIDCPluginProtocol | AnonymousUserOIDCPluginProtocol
+type OIDCPlugin = AbstractUserOIDCPluginProtocol | AnonymousUserOIDCPluginProtocol
 
 
 admin_callback_view = AdminCallbackView.as_view()

--- a/mozilla_django_oidc_db/plugins.py
+++ b/mozilla_django_oidc_db/plugins.py
@@ -30,8 +30,6 @@ missing = object()
 # ABSTRACT BASE CLASSES
 #
 
-type OIDCPlugin = AbstractUserOIDCPlugin | AnonymousUserOIDCPlugin
-
 
 class BaseOIDCPlugin(ABC):
     """

--- a/mozilla_django_oidc_db/registry.py
+++ b/mozilla_django_oidc_db/registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, MutableMapping
 from typing import TYPE_CHECKING
 
 from .constants import UNIQUE_PLUGIN_ID_MAX_LENGTH
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 class OIDCRegistry:
-    _registry: dict[str, OIDCPlugin]
+    _registry: MutableMapping[str, OIDCPlugin]
 
     def __init__(self):
         self._registry = {}

--- a/mozilla_django_oidc_db/registry.py
+++ b/mozilla_django_oidc_db/registry.py
@@ -6,25 +6,23 @@ from typing import TYPE_CHECKING
 from .constants import UNIQUE_PLUGIN_ID_MAX_LENGTH
 
 if TYPE_CHECKING:
-    from .plugins import OIDCPlugin
+    from .plugins import BaseOIDCPlugin
 
 
-class OIDCRegistry:
-    _registry: MutableMapping[str, OIDCPlugin]
+class OIDCRegistry[T: type[BaseOIDCPlugin]]:
+    _registry: MutableMapping[str, T]
 
     def __init__(self):
         self._registry = {}
 
-    def __call__(
-        self, unique_identifier: str
-    ) -> Callable[[type[OIDCPlugin]], type[OIDCPlugin]]:
+    def __call__(self, unique_identifier: str) -> Callable[[T], T]:
         if len(unique_identifier) > UNIQUE_PLUGIN_ID_MAX_LENGTH:
             raise ValueError(
                 f"The unique identifier '{unique_identifier}' is longer than "
                 f"{UNIQUE_PLUGIN_ID_MAX_LENGTH} characters."
             )
 
-        def decorator(plugin_cls: type[OIDCPlugin]) -> type[OIDCPlugin]:
+        def decorator(plugin_cls: T) -> T:
             if unique_identifier in self._registry:
                 raise ValueError(
                     f"The unique identifier '{unique_identifier}' is already present "
@@ -37,13 +35,13 @@ class OIDCRegistry:
 
         return decorator
 
-    def items(self) -> Iterable[tuple[str, OIDCPlugin]]:
+    def items(self) -> Iterable[tuple[str, T]]:
         return self._registry.items()
 
     def __iter__(self):
         return iter(self._registry)
 
-    def __getitem__(self, key: str) -> OIDCPlugin:
+    def __getitem__(self, key: str) -> T:
         return self._registry[key]
 
 

--- a/mozilla_django_oidc_db/typing.py
+++ b/mozilla_django_oidc_db/typing.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Protocol
+from typing import Literal, Protocol
 
 from django.http import HttpRequest, HttpResponseBase
+
+type EndpointFieldNames = Literal[
+    "oidc_op_authorization_endpoint",
+    "oidc_op_token_endpoint",
+    "oidc_op_user_endpoint",
+    "oidc_op_jwks_endpoint",
+    "oidc_op_logout_endpoint",
+]
 
 type JSONPrimitive = str | int | float | bool | None
 type JSONValue = JSONPrimitive | list[JSONValue] | JSONObject

--- a/mozilla_django_oidc_db/typing.py
+++ b/mozilla_django_oidc_db/typing.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Protocol, TypeAlias
+from collections.abc import MutableMapping, Sequence
+from typing import Protocol
 
 from django.http import HttpRequest, HttpResponseBase
 
-JSONPrimitive: TypeAlias = str | int | float | bool | None
-JSONValue: TypeAlias = "JSONPrimitive | list[JSONValue] | JSONObject"
-JSONObject: TypeAlias = dict[str, JSONValue]
+type JSONPrimitive = str | int | float | bool | None
+type JSONValue = JSONPrimitive | list[JSONValue] | JSONObject
+type JSONObject = MutableMapping[str, JSONValue]
 
-ClaimPath: TypeAlias = Sequence[str]
+type ClaimPath = Sequence[str]
 
 
 class DjangoView(Protocol):

--- a/mozilla_django_oidc_db/typing.py
+++ b/mozilla_django_oidc_db/typing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Protocol
 
 from django.http import HttpRequest, HttpResponseBase
@@ -10,6 +10,8 @@ type JSONValue = JSONPrimitive | list[JSONValue] | JSONObject
 type JSONObject = MutableMapping[str, JSONValue]
 
 type ClaimPath = Sequence[str]
+
+type GetParams = Mapping[str, str | bytes]
 
 
 class DjangoView(Protocol):

--- a/mozilla_django_oidc_db/utils.py
+++ b/mozilla_django_oidc_db/utils.py
@@ -7,7 +7,9 @@ from django.contrib.auth.models import Group
 
 import requests
 from glom import Path, PathAccessError, assign, glom
-from requests.utils import _parse_content_type_header
+from requests.utils import (
+    _parse_content_type_header,  # pyright: ignore[reportAttributeAccessIssue]
+)
 
 from .models import OIDCClient
 from .typing import ClaimPath, JSONObject, JSONValue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,10 @@ include = [
     "testapp",
     "tests",
 ]
-ignore = []
+ignore = [
+    # at the time of writing, the type definitions in factory-boy are still broken
+    "mozilla_django_oidc_db/tests/factories.py",
+]
 # pythonVersion = "3.10"
 pythonPlatform = "Linux"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ tests = [
     "pyquery",
     "tox",
     "ruff",
+    "pyright",
+    "django-stubs",
 ]
 docs = [
     "sphinx",
@@ -109,11 +111,21 @@ exclude_also = [
     "@(abc\\.)?abstractmethod",
     "raise NotImplementedError",
     "\\.\\.\\.",
-    "pass",
+    "\\bpass$",
 ]
 omit = [
     "*/migrations/*",
 ]
+
+[tool.pyright]
+include = [
+    "mozilla_django_oidc_db",
+    "testapp",
+    "tests",
+]
+ignore = []
+# pythonVersion = "3.10"
+pythonPlatform = "Linux"
 
 [tool.ruff.lint]
 extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ include = [
 ignore = [
     # at the time of writing, the type definitions in factory-boy are still broken
     "mozilla_django_oidc_db/tests/factories.py",
+    # don't know what's going on here, in particular because it's based on Pydantic I'd
+    # expect this to have zero type checking issues. TODO for later
+    "mozilla_django_oidc_db/setup_configuration/",
 ]
 # pythonVersion = "3.10"
 pythonPlatform = "Linux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,11 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "django>=4.2",
     "django-jsonform>=2.12",

--- a/testapp/migrations/0001_initial.py
+++ b/testapp/migrations/0001_initial.py
@@ -62,7 +62,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_rp_scopes_list",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="OpenID Connect scope"
                         ),

--- a/testapp/migrations/0004_anotheremptyconfig.py
+++ b/testapp/migrations/0004_anotheremptyconfig.py
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "oidc_rp_scopes_list",
-                    django_jsonform.models.fields.ArrayField(
+                    django_jsonform.models.fields.ArrayField(  # type: ignore
                         base_field=models.CharField(
                             max_length=50, verbose_name="OpenID Connect scope"
                         ),

--- a/testapp/plugins.py
+++ b/testapp/plugins.py
@@ -1,4 +1,4 @@
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponseBase
 
 from mozilla_django_oidc_db.plugins import OIDCAdminPlugin
 from mozilla_django_oidc_db.registry import register
@@ -9,8 +9,13 @@ from .views import CustomCallbackView
 callback_view = AdminCallbackView.as_view()
 
 
+class TestPlugin(OIDCAdminPlugin):
+    def handle_callback(self, request: HttpRequest) -> HttpResponseBase:
+        return callback_view(request)
+
+
 @register("test-oidc")
-class OIDCTestPlugin(OIDCAdminPlugin):
+class OIDCTestPlugin(TestPlugin):
     def validate_settings(self) -> None:
         pass
 
@@ -29,36 +34,29 @@ class OIDCTestPlugin(OIDCAdminPlugin):
             },
         }
 
-    def handle_callback(self, request: HttpRequest) -> HttpResponse:
-        return callback_view(request)
-
 
 @register("test-oidc-not-configured")
-class OIDCTestNotConfiguredPlugin(OIDCAdminPlugin):
-    def handle_callback(self, request: HttpRequest) -> HttpResponse:
-        return callback_view(request)
+class OIDCTestNotConfiguredPlugin(TestPlugin):
+    pass
 
 
 @register("test-oidc-another-not-configured")
-class OIDCTestAnotherNotConfiguredPlugin(OIDCAdminPlugin):
-    def handle_callback(self, request: HttpRequest) -> HttpResponse:
-        return callback_view(request)
+class OIDCTestAnotherNotConfiguredPlugin(TestPlugin):
+    pass
 
 
 @register("test-oidc-disabled")
-class OIDCTestDisabledPlugin(OIDCAdminPlugin):
-    def handle_callback(self, request: HttpRequest) -> HttpResponse:
-        return callback_view(request)
+class OIDCTestDisabledPlugin(TestPlugin):
+    pass
 
 
 @register("test-keycloak")
-class OIDCTestKeycloakPlugin(OIDCAdminPlugin):
-    def handle_callback(self, request: HttpRequest) -> HttpResponse:
-        return callback_view(request)
+class OIDCTestKeycloakPlugin(TestPlugin):
+    pass
 
 
 @register("test-keycloak-custom")
 class OIDCTestKeycloakCustomPlugin(OIDCAdminPlugin):
-    def handle_callback(self, request: HttpRequest) -> HttpResponse:
+    def handle_callback(self, request: HttpRequest) -> HttpResponseBase:
         callback_view = CustomCallbackView.as_view()
         return callback_view(request)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -22,6 +22,8 @@ DATABASES = {
     }
 }
 
+FORMS_URLFIELD_ASSUME_HTTPS = True
+
 CACHES = {
     "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     "oidc": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},

--- a/testapp/views.py
+++ b/testapp/views.py
@@ -9,4 +9,6 @@ class PreConfiguredOIDCAuthenticationRequestView(OIDCAuthenticationRequestInitVi
 
 
 class CustomCallbackView(AdminCallbackView):
-    success_url = "/custom-success-url"
+    @property
+    def success_url(self):
+        return "/custom-success-url"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
+import itertools
+from collections.abc import Callable, Iterator
+from typing import TYPE_CHECKING, Protocol, Unpack, overload
 from urllib.parse import parse_qs, urlsplit
 
 from django.contrib.sessions.backends.db import SessionStore
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponseBase
 from django.test import RequestFactory
 
 import pytest
 from pytest_mock import MockFixture
 
 from mozilla_django_oidc_db.constants import OIDC_ADMIN_CONFIG_IDENTIFIER
-from mozilla_django_oidc_db.typing import JSONObject
-from tests.utils import create_or_update_configuration
+
+from .utils import OIDCConfigOptions, create_or_update_configuration
 
 if TYPE_CHECKING:
     from mozilla_django_oidc_db.models import OIDCClient
 
 KEYCLOAK_BASE_URL = "http://localhost:8080/realms/test/"
+
+type Markable = Callable[..., object] | type  # copied from pytest types
 
 
 @pytest.fixture
@@ -66,12 +69,25 @@ def disabled_config(request: pytest.FixtureRequest, db) -> Iterator[OIDCClient]:
     yield config
 
 
-def _get_data_for_config(request: pytest.FixtureRequest) -> JSONObject:
+class OIDCConfigMark(Protocol):
+    @overload
+    def __call__[M: Markable](self, arg: M) -> M: ...
+
+    @overload
+    def __call__(
+        self, **options: Unpack[OIDCConfigOptions]
+    ) -> pytest.MarkDecorator: ...
+
+
+oidcconfig: OIDCConfigMark = pytest.mark.oidcconfig
+
+
+def _get_data_for_config(request: pytest.FixtureRequest) -> OIDCConfigOptions:
     marker = request.node.get_closest_marker("oidcconfig")
-    overrides: dict[str, Any] = marker.kwargs if marker else {}
+    overrides: OIDCConfigOptions = marker.kwargs if marker else {}
     BASE = "https://mock-oidc-provider:9999"
 
-    fields = {
+    fields: OIDCConfigOptions = {
         # Provider config
         "oidc_op_discovery_endpoint": f"{BASE}/oidc/",
         "oidc_op_jwks_endpoint": f"{BASE}/oidc/jwks",
@@ -92,8 +108,9 @@ def _get_data_for_config(request: pytest.FixtureRequest) -> JSONObject:
             },
             "groups_settings": {"make_users_staff": True, "sync": False},
         },
-        **overrides,
     }
+    for key, value in overrides.items():
+        fields[key] = value
     return fields
 
 
@@ -149,17 +166,14 @@ def keycloak_config(request: pytest.FixtureRequest, db) -> Iterator[OIDCClient]:
     endpoints = OIDCProviderForm.get_endpoints_from_discovery(KEYCLOAK_BASE_URL)
 
     marker = request.node.get_closest_marker("oidcconfig")
-    overrides: dict[str, Any] = marker.kwargs if marker else {}
+    overrides: OIDCConfigOptions = marker.kwargs if marker else {}
 
-    fields = {
-        **endpoints,
+    fields: OIDCConfigOptions = {
         "enabled": True,
         "oidc_rp_client_id": "testid",
         "oidc_rp_client_secret": "7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I",
         "oidc_rp_sign_algo": "RS256",
-        **endpoints,
         "oidc_rp_scopes_list": get_default_scopes() + ["bsn", "kvk"],
-        "sync_groups": False,
         "options": {
             "user_settings": {
                 "claim_mappings": {
@@ -169,8 +183,10 @@ def keycloak_config(request: pytest.FixtureRequest, db) -> Iterator[OIDCClient]:
             },
             "groups_settings": {"make_users_staff": True, "sync": False},
         },
-        **overrides,
     }
+    for key, value in itertools.chain(endpoints.items(), overrides.items()):
+        fields[key] = value
+
     config = create_or_update_configuration(
         "test-provider-keycloak", "test-keycloak", fields
     )
@@ -179,6 +195,17 @@ def keycloak_config(request: pytest.FixtureRequest, db) -> Iterator[OIDCClient]:
     )
 
     yield config
+
+
+class AuthRequestMark(Protocol):
+    @overload
+    def __call__[M: Markable](self, arg: M) -> M: ...
+
+    @overload
+    def __call__(self, /, next: str) -> pytest.MarkDecorator: ...
+
+
+auth_request_mark: AuthRequestMark = pytest.mark.auth_request
 
 
 @pytest.fixture
@@ -196,6 +223,19 @@ def auth_request(request: pytest.FixtureRequest, rf: RequestFactory):
     session.save()
     _request.session = session
     return _request
+
+
+class CallbackRequestMark(Protocol):
+    @overload
+    def __call__[M: Markable](self, arg: M) -> M: ...
+
+    @overload
+    def __call__(
+        self, /, init_view: Callable[..., HttpResponseBase]
+    ) -> pytest.MarkDecorator: ...
+
+
+callback_request_mark: CallbackRequestMark = pytest.mark.callback_request
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,7 +2,7 @@ import factory
 
 
 class UserFactory(factory.django.DjangoModelFactory):
-    class Meta:
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = "auth.User"
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth.models import Group, User
+from django.contrib.sessions.backends.base import SessionBase
 from django.core.exceptions import BadRequest, ImproperlyConfigured
 from django.http import HttpRequest
 from django.test import RequestFactory
@@ -634,7 +635,7 @@ def test_groups_claim_wrong_type(dummy_config, callback_request: HttpRequest):
 
 def test_authenticate_without_previous_state(rf: RequestFactory):
     request = rf.get("/oidc/callback", {"state": "foo", "code": "bar"})
-    request.session = {}
+    request.session = SessionBase()
     backend = OIDCAuthenticationBackend()
 
     with pytest.raises(BadRequest):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18,12 +18,14 @@ from mozilla_django_oidc_db.models import (
 from mozilla_django_oidc_db.views import OIDCAuthenticationRequestInitView
 from testapp.backends import MockBackend
 
+from .conftest import callback_request_mark as callback_request, oidcconfig
+
 #
 # DYNAMIC CONFIGURATION TESTS
 #
 
 
-@pytest.mark.oidcconfig(enabled=False)
+@oidcconfig(enabled=False)
 def test_authenticate_oidc_not_enabled(dummy_config, callback_request: HttpRequest):
     backend = OIDCAuthenticationBackend()
 
@@ -35,8 +37,8 @@ def test_authenticate_oidc_not_enabled(dummy_config, callback_request: HttpReque
 
 
 @pytest.mark.django_db
-@pytest.mark.oidcconfig
-@pytest.mark.callback_request(
+@oidcconfig
+@callback_request(
     init_view=OIDCAuthenticationRequestInitView.as_view(identifier="test-oidc-disabled")
 )
 def test_authentication_loads_config_from_init_state(
@@ -90,7 +92,7 @@ def test_settings_still_validated(settings, sign_alg: str):
 #
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     extra_options={
         "user_settings.claim_mappings.username": ["sub"],
@@ -135,7 +137,7 @@ def test_obfuscates_sensitive_claims(dummy_config, caplog):
 #
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -167,7 +169,7 @@ def test_create_user_with_default_config(dummy_config, callback_request: HttpReq
     assert user.last_name == "Doe"
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -196,7 +198,7 @@ def test_case_insensitive_username_lookups(
     assert User.objects.count() == 1
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -239,7 +241,7 @@ def test_create_user_with_custom_and_complex_config(
     assert user.last_name == "Doe"
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -272,7 +274,7 @@ def test_create_user_with_mapped_groups(dummy_config, callback_request: HttpRequ
     assert group_names == {"supergroup"}
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -303,7 +305,7 @@ def test_groups_claim_string_instead_of_list(
     assert set(user.groups.values_list("name", flat=True)) == {"admins"}
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -364,7 +366,7 @@ def test_update_user_with_custom_and_complex_config(
     assert set(user.groups.values_list("name", flat=True)) == {"supergroup"}
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -393,7 +395,7 @@ def test_authenticate_user_no_group_sync_without_claim(
     assert not user.groups.exists()
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -421,7 +423,7 @@ def test_authenticate_user_groups_glob_pattern(
     assert set(user.groups.values_list("name", flat=True)) == {"myapp:editor"}
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -455,7 +457,7 @@ def test_authenticate_user_groups_and_default_groups(
     }
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -479,7 +481,7 @@ def test_authenticate_user_make_staff(dummy_config, callback_request: HttpReques
     assert user.is_superuser
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -507,7 +509,7 @@ def test_authenticate_user_make_superuser_based_on_group(
     assert not Group.objects.exists()
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -534,7 +536,7 @@ def test_remove_superuser_based_on_group(dummy_config, callback_request: HttpReq
     assert not user.is_superuser
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -568,7 +570,7 @@ def test_do_nothing_if_no_superuser_groups_configured(
 #
 
 
-@pytest.mark.oidcconfig(enabled=True)
+@oidcconfig(enabled=True)
 def test_authenticate_called_without_args(dummy_config):
     backend = OIDCAuthenticationBackend()
 
@@ -577,7 +579,7 @@ def test_authenticate_called_without_args(dummy_config):
     assert user is None
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -592,9 +594,7 @@ def test_username_claim_empty(dummy_config, callback_request: HttpRequest):
     assert user is None
 
 
-@pytest.mark.oidcconfig(
-    enabled=True, userinfo_claims_source=UserInformationClaimsSources.id_token
-)
+@oidcconfig(enabled=True, userinfo_claims_source=UserInformationClaimsSources.id_token)
 def test_empty_claims(dummy_config, callback_request: HttpRequest):
     backend = MockBackend(claims={})
 
@@ -603,7 +603,7 @@ def test_empty_claims(dummy_config, callback_request: HttpRequest):
     assert user is None
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={

--- a/tests/test_callback_flow.py
+++ b/tests/test_callback_flow.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 from django.db import IntegrityError
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponseRedirect
 from django.test import Client
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -228,6 +228,7 @@ def test_wrong_config_model_used(
     )
 
     assert callback_response.status_code == 302
+    assert isinstance(callback_response, HttpResponseRedirect)
     assert callback_response.url == "/admin/login/failure/"
 
 

--- a/tests/test_callback_flow.py
+++ b/tests/test_callback_flow.py
@@ -1,3 +1,5 @@
+from typing import Protocol
+
 from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.http import HttpRequest, HttpResponseRedirect
@@ -16,7 +18,15 @@ from mozilla_django_oidc_db.typing import JSONObject
 from mozilla_django_oidc_db.views import OIDCAuthenticationRequestInitView
 from testapp.backends import MockBackend
 
+from .conftest import auth_request_mark as auth_request, oidcconfig
 from .factories import UserFactory
+
+
+class CallbackRequestMark(Protocol):
+    def __call__(self, claims: JSONObject) -> pytest.MarkDecorator: ...
+
+
+mock_backend_claims: CallbackRequestMark = pytest.mark.mock_backend_claims
 
 
 @pytest.fixture
@@ -41,10 +51,8 @@ def callback_client(callback_request: HttpRequest, client: Client) -> Client:
     return client
 
 
-@pytest.mark.mock_backend_claims(
-    {"email": "collision@example.com", "sub": "some_username"}
-)
-@pytest.mark.oidcconfig(
+@mock_backend_claims({"email": "collision@example.com", "sub": "some_username"})
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
 )
@@ -84,14 +92,14 @@ def test_duplicate_email_unique_constraint_violated(
     assertContains(error_page, "duplicate key value violates unique constraint")
 
 
-@pytest.mark.mock_backend_claims(
+@mock_backend_claims(
     {
         "sub": "some_username",
         "email": "collision@example.com",
         "wrong_is_superuser_value_type": "",  # should be boolean instead of string
     }
 )
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
     extra_options={
@@ -124,14 +132,14 @@ def test_validation_error_during_authentication(
     assertContains(error_page, expected_error)
 
 
-@pytest.mark.mock_backend_claims(
+@mock_backend_claims(
     {
         "email": "nocollision@example.com",
         "sub": "some_username",
     }
 )
-@pytest.mark.auth_request(next="/admin/")
-@pytest.mark.oidcconfig(
+@auth_request(next="/admin/")
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
 )
@@ -150,8 +158,8 @@ def test_happy_flow(
     assert user.username == "some_username"
 
 
-@pytest.mark.mock_backend_claims({})
-@pytest.mark.oidcconfig(
+@mock_backend_claims({})
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
 )
@@ -207,7 +215,7 @@ def test_invalid_reference_to_config_identifier(
 
 
 @pytest.mark.django_db
-@pytest.mark.oidcconfig(enabled=False, oidc_op_authorization_endpoint="bad")
+@oidcconfig(enabled=False, oidc_op_authorization_endpoint="bad")
 def test_wrong_config_model_used(
     dummy_config: OIDCClient,
     auth_request: HttpRequest,
@@ -232,8 +240,8 @@ def test_wrong_config_model_used(
     assert callback_response.url == "/admin/login/failure/"
 
 
-@pytest.mark.auth_request(next="/admin/")
-@pytest.mark.oidcconfig(
+@auth_request(next="/admin/")
+@oidcconfig(
     enabled=True,
     userinfo_claims_source=UserInformationClaimsSources.id_token,
 )

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -4,7 +4,7 @@ Test the OIDC Authenticaton Request flow with our custom views.
 
 from urllib.parse import parse_qs, urlsplit
 
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import reverse
 
 import pytest
@@ -14,6 +14,7 @@ from mozilla_django_oidc_db.exceptions import OIDCProviderOutage
 from mozilla_django_oidc_db.plugins import OIDCAdminPlugin
 from mozilla_django_oidc_db.registry import register
 from mozilla_django_oidc_db.tests.factories import OIDCClientFactory
+from mozilla_django_oidc_db.typing import GetParams
 from mozilla_django_oidc_db.views import OIDCAuthenticationRequestInitView
 
 
@@ -87,9 +88,10 @@ def test_overwrite_scope(dummy_config, auth_request):
 
     @register("test-extra-scope")
     class OIDCTestExtraParamsPlugin(OIDCAdminPlugin):
-        def get_extra_params(self, request: HttpRequest, extra_params: dict) -> dict:
-            extra_params["scope"] = "not-email and-extra"
-            return extra_params
+        def get_extra_params(
+            self, request: HttpRequest, extra_params: GetParams
+        ) -> GetParams:
+            return {**extra_params, "scope": "not-email and-extra"}
 
     OIDCClientFactory.create(identifier="test-extra-scope")
 
@@ -97,6 +99,7 @@ def test_overwrite_scope(dummy_config, auth_request):
     redirect_response = oidc_init(auth_request)
 
     assert redirect_response.status_code == 302
+    assert isinstance(redirect_response, HttpResponseRedirect)
 
     parsed_url = urlsplit(redirect_response.url)
     query = parse_qs(parsed_url.query)

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -17,10 +17,10 @@ from mozilla_django_oidc_db.tests.factories import OIDCClientFactory
 from mozilla_django_oidc_db.typing import GetParams
 from mozilla_django_oidc_db.views import OIDCAuthenticationRequestInitView
 
+from .conftest import auth_request_mark as auth_request, oidcconfig
 
-@pytest.mark.oidcconfig(
-    oidc_op_authorization_endpoint="http://localhost:8080/openid-connect/auth"
-)
+
+@oidcconfig(oidc_op_authorization_endpoint="http://localhost:8080/openid-connect/auth")
 def test_default_config_flow(filled_admin_config, client):
     start_url = reverse("oidc_authentication_init")
     assert start_url == "/oidc/authenticate/"
@@ -44,7 +44,7 @@ def test_default_config_flow(filled_admin_config, client):
     assert client.session["oidc-db_redirect_next"] == "/admin/"
 
 
-@pytest.mark.oidcconfig(oidc_keycloak_idp_hint="keycloak-idp2")
+@oidcconfig(oidc_keycloak_idp_hint="keycloak-idp2")
 def test_keycloak_idp_hint_via_config(filled_admin_config, settings, client):
     settings.OIDC_KEYCLOAK_IDP_HINT = "keycloak-idp1"
     start_url = reverse("oidc_authentication_init")
@@ -58,7 +58,7 @@ def test_keycloak_idp_hint_via_config(filled_admin_config, settings, client):
     assert query["kc_idp_hint"] == ["keycloak-idp2"]
 
 
-@pytest.mark.oidcconfig(check_op_availability=True)
+@oidcconfig(check_op_availability=True)
 def test_check_idp_availability_not_available(
     filled_admin_config, settings, client, requests_mock
 ):
@@ -69,7 +69,7 @@ def test_check_idp_availability_not_available(
         client.get(start_url)
 
 
-@pytest.mark.oidcconfig(check_op_availability=True)
+@oidcconfig(check_op_availability=True)
 def test_check_idp_availability_available(
     filled_admin_config, settings, client, requests_mock
 ):
@@ -81,8 +81,8 @@ def test_check_idp_availability_available(
     assert response.status_code == 302
 
 
-@pytest.mark.oidcconfig(oidc_rp_scopes_list=["email"])
-@pytest.mark.auth_request
+@oidcconfig(oidc_rp_scopes_list=["email"])
+@auth_request
 def test_overwrite_scope(dummy_config, auth_request):
     """Test whether the scopes specified in the configuration can be overwritten."""
 

--- a/tests/test_init_flow_custom_config.py
+++ b/tests/test_init_flow_custom_config.py
@@ -5,6 +5,7 @@ Test the init flow.
 from urllib.parse import parse_qs, urlsplit
 
 from django.core.exceptions import DisallowedRedirect
+from django.http import HttpResponseRedirect
 
 import pytest
 
@@ -28,6 +29,7 @@ def test_redirects_to_oidc_provider(dummy_config, auth_request):
     response = init_view(auth_request, return_url="/fixed-next")
 
     assert response.status_code == 302
+    assert isinstance(response, HttpResponseRedirect)
     parsed_url = urlsplit(response.url)
     assert parsed_url.scheme == "https"
     assert parsed_url.netloc == "example.com"

--- a/tests/test_init_flow_custom_config.py
+++ b/tests/test_init_flow_custom_config.py
@@ -12,6 +12,8 @@ import pytest
 from mozilla_django_oidc_db.exceptions import OIDCProviderOutage
 from mozilla_django_oidc_db.views import OIDCAuthenticationRequestInitView
 
+from .conftest import oidcconfig
+
 pytestmark = [pytest.mark.django_db]
 
 init_view = OIDCAuthenticationRequestInitView.as_view(
@@ -19,7 +21,7 @@ init_view = OIDCAuthenticationRequestInitView.as_view(
 )
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     oidc_rp_client_id="fixed_client_id",
     oidc_rp_client_secret="supersecret",
@@ -45,7 +47,7 @@ def test_redirects_to_oidc_provider(dummy_config, auth_request):
     assert auth_request.session["oidc-db_redirect_next"] == "/fixed-next"
 
 
-@pytest.mark.oidcconfig()
+@oidcconfig
 def test_suspicious_return_url(dummy_config, auth_request):
     with pytest.raises(DisallowedRedirect):
         init_view(auth_request, return_url="http://evil.com/steal-my-data")
@@ -59,7 +61,7 @@ def test_suspicious_return_url(dummy_config, auth_request):
         {"return_url": None},
     ),
 )
-@pytest.mark.oidcconfig()
+@oidcconfig
 def test_forgotten_return_url(dummy_config, auth_request, get_kwargs):
     with pytest.raises(ValueError):
         init_view(auth_request, **get_kwargs)
@@ -75,7 +77,7 @@ oidc_init_with_idp_check = IDPCheckInitView.as_view(
 )
 
 
-@pytest.mark.oidcconfig(check_op_availability=True)
+@oidcconfig(check_op_availability=True)
 def test_idp_check_mechanism(dummy_config, auth_request, settings):
     with pytest.raises(OIDCProviderOutage):
         oidc_init_with_idp_check(auth_request)

--- a/tests/test_integration_multiple_configs.py
+++ b/tests/test_integration_multiple_configs.py
@@ -6,11 +6,12 @@ from requests import Session
 
 from mozilla_django_oidc_db.models import OIDCClient
 
+from .conftest import oidcconfig
 from .utils import keycloak_login
 
 
 @pytest.mark.vcr
-@pytest.mark.oidcconfig(make_users_staff=True)
+@oidcconfig(extra_options={"make_users_staff": True})
 def test_use_config_class_from_state_over_config_class_from_session(
     keycloak_config: OIDCClient,
     dummy_config: OIDCClient,

--- a/tests/test_integration_oidc_flow_variants.py
+++ b/tests/test_integration_oidc_flow_variants.py
@@ -8,6 +8,7 @@ from mozilla_django_oidc_db.models import (
     UserInformationClaimsSources,
 )
 
+from .conftest import oidcconfig
 from .utils import keycloak_login
 
 KEYCLOAK_BASE_URL = "http://localhost:8080/realms/test/"
@@ -88,7 +89,7 @@ def test_credentials_in_basic_auth_header(
 
 
 @pytest.mark.vcr
-@pytest.mark.oidcconfig(
+@oidcconfig(
     # Set up client configured to return JWT from userinfo endpoint instead of plain
     # JSON. Credentials from ``docker/import`` realm export.
     oidc_rp_client_id="test-userinfo-jwt",
@@ -115,7 +116,7 @@ def test_return_jwt_from_userinfo_endpoint(
 
 
 @pytest.mark.vcr
-@pytest.mark.oidcconfig(make_users_staff=True)
+@oidcconfig(extra_options={"make_users_staff": True})
 def test_session_refresh(
     keycloak_config,
     settings,

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -7,6 +7,7 @@ from requests import Session
 from mozilla_django_oidc_db.models import OIDCClient
 from mozilla_django_oidc_db.utils import do_op_logout
 
+from .conftest import oidcconfig
 from .utils import keycloak_login
 
 
@@ -51,7 +52,7 @@ def kc_session(
 
 
 @pytest.mark.vcr
-@pytest.mark.oidcconfig(oidc_op_logout_endpoint="")
+@oidcconfig(oidc_op_logout_endpoint="")
 def test_logout_without_endpoint_configured(
     keycloak_config: OIDCClient,
     kc_session: tuple[Client, Session],
@@ -88,7 +89,7 @@ def test_logout_with_logout_endpoint_configured(
     assert kc_response.headers["Content-Type"].startswith("text/html")
 
 
-@pytest.mark.oidcconfig(oidc_op_logout_endpoint="https://example.com/oidc/logout")
+@oidcconfig(oidc_op_logout_endpoint="https://example.com/oidc/logout")
 def test_logout_response_has_redirect(dummy_config: OIDCClient, requests_mock):
     requests_mock.post(
         "https://example.com/oidc/logout",

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,13 +4,14 @@ import pytest
 
 from mozilla_django_oidc_db.registry import register as registry
 
+from .conftest import oidcconfig
 from .factories import UserFactory
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
-    username_claim=["username"],
     extra_options={
+        "user_settings.claim_mappings.username": ["username"],
         "user_settings.claim_mappings.first_name": [],
         "user_settings.claim_mappings.email": ["email"],
         "groups_settings.superuser_group_names": ["Superuser"],
@@ -46,10 +47,10 @@ def test_update_user_from_claims(dummy_config):
     assert user.is_superuser
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
-    username_claim=["username"],
     extra_options={
+        "user_settings.claim_mappings.username": ["username"],
         "groups_settings.claim_mapping": ["not-present"],
     },
 )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,6 +13,8 @@ from mozilla_django_oidc_db.middleware import SessionRefresh
 from mozilla_django_oidc_db.models import OIDCClient
 from testapp.views import PreConfiguredOIDCAuthenticationRequestView
 
+from .conftest import oidcconfig
+
 
 @pytest.mark.parametrize(
     "setting",
@@ -45,7 +47,7 @@ def test_backend_without_initialization_request_raises(setting: str):
         ("OIDC_RP_IDP_SIGN_KEY", None),
     ),
 )
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     oidc_rp_client_id="testid",
     oidc_rp_client_secret="secret",
@@ -67,7 +69,7 @@ def test_backend_reads_settings_from_model(
     assert value == expected
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     oidc_rp_client_id="testid",
     oidc_op_authorization_endpoint="http://some.endpoint/v1/auth",
@@ -82,7 +84,7 @@ def test_view_settings_derived_from_model_oidc_enabled(
     assert view.OIDC_OP_AUTH_ENDPOINT == "http://some.endpoint/v1/auth"
 
 
-@pytest.mark.oidcconfig(
+@oidcconfig(
     enabled=True,
     oidc_rp_client_id="testid",
     oidc_op_authorization_endpoint="http://some.endpoint/v1/auth",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.contrib.sessions.backends.base import SessionBase
 from django.test import RequestFactory
 
 import pytest
@@ -94,7 +95,8 @@ def test_middleware_use_falsy_default(
     middleware = SessionRefresh(lambda x: x)
 
     request = rf.get("/")
-    request.session = {CONFIG_IDENTIFIER_SESSION_KEY: dummy_config.identifier}
+    request.session = SessionBase()
+    request.session.update({CONFIG_IDENTIFIER_SESSION_KEY: dummy_config.identifier})
 
     mocker.patch.object(middleware, "is_refreshable_url", return_value=True)
     middleware._set_config_from_request(request)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -6,8 +6,10 @@ from mozilla_django_oidc_db.templatetags.mozilla_django_oidc_db import (
     get_oidc_admin_client,
 )
 
+from .conftest import oidcconfig
 
-@pytest.mark.oidcconfig(enabled=True)
+
+@oidcconfig(enabled=True)
 def test_templatetag_admin_oidc_enabled(filled_admin_config):
     retrieved_client = get_oidc_admin_client()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,16 @@
+from collections.abc import Sequence
 from contextlib import nullcontext
+from typing import TypedDict
 
 from glom import assign
 from pyquery import PyQuery as pq
 from requests import Session
 
-from mozilla_django_oidc_db.models import OIDCClient, OIDCProvider
+from mozilla_django_oidc_db.models import (
+    OIDCClient,
+    OIDCProvider,
+    UserInformationClaimsSources,
+)
 from mozilla_django_oidc_db.typing import JSONObject
 
 
@@ -52,8 +58,38 @@ def keycloak_login(
         return redirect_uri
 
 
+class OIDCConfigOptions(TypedDict, total=False):
+    """
+    Provider and/or client configuration options, which map to model fields.
+    """
+
+    # provider fields
+    oidc_op_discovery_endpoint: str
+    oidc_op_jwks_endpoint: str
+    oidc_op_authorization_endpoint: str
+    oidc_op_token_endpoint: str
+    oidc_op_user_endpoint: str
+    oidc_op_logout_endpoint: str
+    oidc_token_use_basic_auth: bool
+    oidc_use_nonce: bool
+    oidc_nonce_size: int
+    oidc_state_size: int
+    # client fields
+    enabled: bool
+    oidc_rp_client_id: str
+    oidc_rp_client_secret: str
+    oidc_rp_scopes_list: Sequence[str]
+    oidc_rp_sign_algo: str
+    oidc_rp_idp_sign_key: str
+    oidc_keycloak_idp_hint: str
+    userinfo_claims_source: UserInformationClaimsSources
+    check_op_availability: bool
+    options: JSONObject
+    extra_options: JSONObject
+
+
 def create_or_update_configuration(
-    identifier_provider: str, identifier_config: str, data: JSONObject
+    identifier_provider: str, identifier_config: str, data: OIDCConfigOptions
 ) -> OIDCClient:
     """Create or update a OIDCClient and OIDCProvider.
 
@@ -100,10 +136,10 @@ def create_or_update_configuration(
         defaults=fields_config,
     )
     config.oidc_provider = oidc_provider
-    extra_options = data.get("extra_options", {})
-    assert isinstance(extra_options, dict)
-    for path, value in extra_options.items():
-        assign(config.options, path, value)
+    extra_options = data.get("extra_options")
+    if extra_options:
+        for path, value in extra_options.items():
+            assign(config.options, path, value)
     config.save()
 
     return config

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,7 @@ from pyquery import PyQuery as pq
 from requests import Session
 
 from mozilla_django_oidc_db.models import OIDCClient, OIDCProvider
+from mozilla_django_oidc_db.typing import JSONObject
 
 
 def keycloak_login(
@@ -52,18 +53,21 @@ def keycloak_login(
 
 
 def create_or_update_configuration(
-    identifier_provider: str, identifier_config: str, data: dict
+    identifier_provider: str, identifier_config: str, data: JSONObject
 ) -> OIDCClient:
     """Create or update a OIDCClient and OIDCProvider.
 
-    The fields for the OIDCProvider are extracted from data and used to create/update the provider configuration.
-    Then the fields for the OIDCClient are extracted and used to create/update the configuration. The foreign key
-    to the provider will point to the just created/updated provider.
+    The fields for the OIDCProvider are extracted from data and used to create/update
+    the provider configuration. Then the fields for the OIDCClient are extracted and
+    used to create/update the configuration. The foreign key to the provider will point
+    to the just created/updated provider.
 
-    It is possible to provide an extra field in the ``data`` dict called ``extra_options``. This is a dict with as key
-    a dotted path for within the ``options`` field of the configuration, and as value the value to use for the specified field.
-    For example, if ``extra_options`` is ``{"user_settings.claim_mappings.username": ["sub", "blob"]}``, then the configuration
-    will have an options field:
+    It is possible to provide an extra field in the ``data`` dict called
+    ``extra_options``. This is a dict with as key a dotted path for within the
+    ``options`` field of the configuration, and as value the value to use for the
+    specified field. For example, if ``extra_options`` is
+    ``{"user_settings.claim_mappings.username": ["sub", "blob"]}``, then the
+    configuration will have an options field:
 
     .. code:: python
 
@@ -96,7 +100,9 @@ def create_or_update_configuration(
         defaults=fields_config,
     )
     config.oidc_provider = oidc_provider
-    for path, value in data.get("extra_options", {}).items():
+    extra_options = data.get("extra_options", {})
+    assert isinstance(extra_options, dict)
+    for path, value in extra_options.items():
         assign(config.options, path, value)
     config.save()
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{313}-django{52}-mozilla_django_oidc{40}-setup_config_{enabled,disabled}
     ruff
     docs
+    typecheck
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -65,3 +66,12 @@ commands=
     pytest check_sphinx.py -v \
     --tb=auto \
     {posargs}
+
+[testenv:typecheck]
+basepython=python
+skipsdist=true
+extras =
+    mozilla-django-oidc~=4.0.0
+    setup-configuration
+    tests
+commands = pyright

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312}-django{42,52}-mozilla_django_oidc{40}-setup_config_{enabled,disabled}
+    py{312}-django{42,52}-mozilla_django_oidc{40}-setup_config_{enabled,disabled}
     py{313}-django{52}-mozilla_django_oidc{40}-setup_config_{enabled,disabled}
     ruff
     docs
@@ -9,8 +9,6 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
     3.12: py312
     3.13: py313
 


### PR DESCRIPTION
* Require Python 3.12+ (because it has nicer typing syntax)
* Ignore factory boy & setup-configuration modules, these are quite hopeless to fix at this point
* Refactored the interfaces for plugins - there is now an actual base class that guarantees some behaviour and obsoletes the protocols
* Updated test code to also pass type checking in CI