### PR TITLE
:bug: pin mozilla-django-oidc to <5.0.0 to avoid breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "django>=4.2",
     "django-jsonform>=2.12",
     "glom",
-    "mozilla-django-oidc>=3.0.0",
+    "mozilla-django-oidc>=3.0.0,<5.0.0",
     "typing-extensions>=4.0.0",
 ]
 


### PR DESCRIPTION
Closes #168.