### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,31 @@
 Changelog
 =========
 
+2.0.0 (2026-03-10)
+==================
+
+Maintenance release.
+
+**💥 Breaking changes**
+
+* [#164] The legacy ``OpenIDConnectConfig`` model reference is removed. If you have
+  references to this model in your migrations, you should first upgrade to 1.0+ and
+  squash your migrations, or edit your existing migration files.
+* [#169] Dropped support for mozilla-django-oidc 4 and older.
+
+**New features**
+
+* [#169] Added support for mozilla-django-oidc 5.0+.
+
+**Bugfixes**
+
+* [#171] Fixed missing validation in setup-configuration when importing invalid client
+  configuration identifiers.
+
+**Project maintenance**
+
+* Fixed missing imports in documentation code samples.
+
 1.1.1 (2025-11-19)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 mozilla-django-oidc-db
 ======================
 
-:Version: 1.1.1
+:Version: 2.0.0
 :Source: https://github.com/maykinmedia/mozilla-django-oidc-db
 :Keywords: OIDC, django, database, authentication
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ copyright = "2024, Maykin Media"
 author = "Maykin Media"
 
 # The full version, including alpha/beta/rc tags
-release = "1.1.1"
+release = "2.0.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-django-oidc-db"
-version = "1.1.1"
+version = "2.0.0"
 description = "A database-backed configuration for mozilla-django-oidc"
 authors = [
     {name = "Maykin Media", email = "support@maykinmedia.nl"}
@@ -84,7 +84,7 @@ markers = [
 ]
 
 [tool.bumpversion]
-current_version = "1.1.1"
+current_version = "2.0.0"
 files = [
     {filename = "pyproject.toml"},
     {filename = "README.rst"},


### PR DESCRIPTION
Small breaking changes, most importantly this enables upgrading to the latest mozilla-django-oidc version.