### PR TITLE
[#122] Add one-time OIDC account-merge onboarding flow

### DIFF
--- a/mozilla_django_oidc_db/exceptions.py
+++ b/mozilla_django_oidc_db/exceptions.py
@@ -1,4 +1,11 @@
-from .typing import ClaimPath
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .typing import ClaimPath, JSONObject
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractUser
 
 
 class OIDCProviderOutage(Exception):
@@ -13,3 +20,21 @@ class MissingIdentifierClaim(Exception):
 
 class MissingInitialisation(Exception):
     pass
+
+
+class AccountMergeRequired(Exception):
+    """
+    Raised during OIDC authentication when an existing Django account shares the
+    same email address as the OIDC identity, but the username does not match.
+
+    Raising this exception interrupts the normal OIDC callback flow and triggers
+    the one-time account-merge onboarding process, where the user must confirm
+    ownership of the existing account by providing their current password.
+
+    Only raised when ``allow_account_merge`` is enabled on the :class:`OIDCClient`.
+    """
+
+    def __init__(self, candidate: AbstractUser, claims: JSONObject):
+        self.candidate = candidate
+        self.claims = claims
+        super().__init__()

--- a/mozilla_django_oidc_db/forms.py
+++ b/mozilla_django_oidc_db/forms.py
@@ -3,6 +3,8 @@ from collections.abc import Mapping
 from urllib.parse import urljoin
 
 from django import forms
+from django.contrib.auth import get_user_model
+from django.core.exceptions import SuspiciousOperation
 from django.utils.translation import gettext_lazy as _
 
 import requests
@@ -12,6 +14,48 @@ from .models import OIDCProvider
 from .typing import EndpointFieldNames
 
 type EndpointsMapping = Mapping[EndpointFieldNames, str]
+
+
+class AccountMergeForm(forms.Form):
+    """
+    Password-confirmation form shown during the OIDC account-merge onboarding flow.
+
+    The user must enter the password of their *existing* Django account to prove
+    ownership before the accounts are merged.
+    """
+
+    password = forms.CharField(
+        label=_("Current password"),
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
+        help_text=_(
+            "Enter the password you currently use to log in to confirm that you "
+            "own this account."
+        ),
+    )
+
+    def __init__(self, *args, user_pk: int, **kwargs):
+        super().__init__(*args, **kwargs)
+        UserModel = get_user_model()
+        try:
+            self._candidate_user = UserModel.objects.get(pk=user_pk)
+        except UserModel.DoesNotExist as exc:
+            raise SuspiciousOperation(
+                "The account-merge candidate user was not found."
+            ) from exc
+
+    def clean_password(self):
+        password = self.cleaned_data["password"]
+        if not self._candidate_user.check_password(password):
+            raise forms.ValidationError(
+                _("Incorrect password. Please try again."),
+                code="invalid_password",
+            )
+        return password
+
+    def get_user(self):
+        """Return the candidate user after successful validation."""
+        return self._candidate_user
 
 
 class OIDCProviderForm(forms.ModelForm):

--- a/mozilla_django_oidc_db/migrations/0010_oidcclient_allow_account_merge.py
+++ b/mozilla_django_oidc_db/migrations/0010_oidcclient_allow_account_merge.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("mozilla_django_oidc_db", "0009_delete_openidconnectconfig"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="oidcclient",
+            name="allow_account_merge",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When enabled, a first-time OIDC login whose username does not match any "
+                    "existing account but whose email address does will trigger a one-time "
+                    "account-merge flow. The user must confirm ownership of the existing "
+                    "account by providing their current password before the accounts are merged. "
+                    "After merging the existing username is replaced with the OIDC identifier "
+                    "and the local password is cleared."
+                ),
+                verbose_name="allow account merge",
+            ),
+        ),
+    ]

--- a/mozilla_django_oidc_db/models.py
+++ b/mozilla_django_oidc_db/models.py
@@ -232,6 +232,18 @@ class OIDCClient(models.Model):
     )
 
     # Additional settings
+    allow_account_merge = models.BooleanField(
+        _("allow account merge"),
+        default=False,
+        help_text=_(
+            "When enabled, a first-time OIDC login whose username does not match any "
+            "existing account but whose email address does will trigger a one-time "
+            "account-merge flow. The user must confirm ownership of the existing "
+            "account by providing their current password before the accounts are merged. "
+            "After merging the existing username is replaced with the OIDC identifier "
+            "and the local password is cleared."
+        ),
+    )
     check_op_availability = models.BooleanField(
         verbose_name=_("check OIDC Provider availability"),
         default=False,

--- a/mozilla_django_oidc_db/plugins.py
+++ b/mozilla_django_oidc_db/plugins.py
@@ -14,7 +14,7 @@ from glom import Path, glom
 
 from .config import get_setting_from_config
 from .constants import OIDC_ADMIN_CONFIG_IDENTIFIER
-from .exceptions import MissingIdentifierClaim
+from .exceptions import AccountMergeRequired, MissingIdentifierClaim
 from .models import OIDCClient
 from .registry import register
 from .schemas import ADMIN_OPTIONS_SCHEMA
@@ -167,6 +167,18 @@ class AbstractUserOIDCPlugin(BaseOIDCPlugin):
             """
             ...
 
+        def merge_accounts(
+            self, user: AbstractUser, claims: JSONObject
+        ) -> AbstractUser:
+            """
+            Merge an existing Django user account with an OIDC identity.
+
+            Called by the account-merge view after the user has confirmed ownership
+            of the existing account. Should rename the user's username to the OIDC
+            identifier from claims, clear the local password, and sync other fields.
+            """
+            ...
+
 
 #
 # CONCRETE IMPLEMENTATIONS
@@ -262,6 +274,33 @@ class OIDCAdminPlugin(AbstractUserOIDCPlugin):
 
         return UserModel.objects.filter(**{lookup: username})
 
+    def _find_existing_user_by_email(
+        self, claims: JSONObject
+    ) -> AbstractUser | None:
+        """
+        Look up an existing Django user by the email in the OIDC claims.
+
+        Returns the user if exactly one match is found, ``None`` otherwise.
+        Requires the ``email`` claim mapping to be configured.
+        """
+        UserModel = get_user_model()
+        config = self.get_config()
+
+        email_claim_path = (
+            config.options["user_settings"]["claim_mappings"].get("email") or []
+        )
+        if not email_claim_path:
+            return None
+
+        email = glom(claims, Path(*email_claim_path), default=None)
+        if not email:
+            return None
+
+        try:
+            return UserModel.objects.get(email__iexact=str(email))
+        except (UserModel.DoesNotExist, UserModel.MultipleObjectsReturned):
+            return None
+
     def create_user(self, claims: JSONObject) -> AbstractUser:
         """Return object for a newly created user account."""
         UserModel = get_user_model()
@@ -270,6 +309,15 @@ class OIDCAdminPlugin(AbstractUserOIDCPlugin):
                 "The user model must inherit from AbstractUser."
             )
 
+        config = self.get_config()
+
+        # Before creating a new account, check whether an existing account with
+        # the same email should be merged instead.
+        if config.allow_account_merge:
+            candidate = self._find_existing_user_by_email(claims)
+            if candidate is not None:
+                raise AccountMergeRequired(candidate=candidate, claims=claims)
+
         username = self.get_username(claims)
 
         logger.debug("Creating Admin OIDC user: %s", username)
@@ -277,6 +325,31 @@ class OIDCAdminPlugin(AbstractUserOIDCPlugin):
         user = UserModel.objects.create_user(**{UserModel.USERNAME_FIELD: username})
         self.update_user(user, claims)
         return user
+
+    def merge_accounts(self, user: AbstractUser, claims: JSONObject) -> AbstractUser:
+        """
+        Merge an existing Django user account with an OIDC identity.
+
+        Renames the user's username to the OIDC identifier from the claims,
+        clears the local password so subsequent logins must go through OIDC,
+        and syncs any other mapped claim fields.
+        """
+        UserModel = get_user_model()
+        oidc_username = self.get_username(claims)
+        old_username = getattr(user, UserModel.USERNAME_FIELD)
+
+        logger.info(
+            "Merging existing user account '%s' (pk=%s) with OIDC identity '%s'",
+            old_username,
+            user.pk,
+            oidc_username,
+        )
+
+        setattr(user, UserModel.USERNAME_FIELD, oidc_username)
+        user.set_unusable_password()
+        user.save(update_fields=[UserModel.USERNAME_FIELD, "password"])
+
+        return self.update_user(user, claims)
 
     def update_user(self, user: AbstractUser, claims: JSONObject) -> AbstractUser:
         """

--- a/mozilla_django_oidc_db/plugins.py
+++ b/mozilla_django_oidc_db/plugins.py
@@ -274,9 +274,7 @@ class OIDCAdminPlugin(AbstractUserOIDCPlugin):
 
         return UserModel.objects.filter(**{lookup: username})
 
-    def _find_existing_user_by_email(
-        self, claims: JSONObject
-    ) -> AbstractUser | None:
+    def _find_existing_user_by_email(self, claims: JSONObject) -> AbstractUser | None:
         """
         Look up an existing Django user by the email in the OIDC claims.
 

--- a/mozilla_django_oidc_db/plugins.py
+++ b/mozilla_django_oidc_db/plugins.py
@@ -282,6 +282,10 @@ class OIDCAdminPlugin(AbstractUserOIDCPlugin):
         Requires the ``email`` claim mapping to be configured.
         """
         UserModel = get_user_model()
+        if TYPE_CHECKING:
+            assert issubclass(UserModel, AbstractUser), (
+                "The user model must inherit from AbstractUser."
+            )
         config = self.get_config()
 
         email_claim_path = (
@@ -333,6 +337,10 @@ class OIDCAdminPlugin(AbstractUserOIDCPlugin):
         and syncs any other mapped claim fields.
         """
         UserModel = get_user_model()
+        if TYPE_CHECKING:
+            assert issubclass(UserModel, AbstractUser), (
+                "The user model must inherit from AbstractUser."
+            )
         oidc_username = self.get_username(claims)
         old_username = getattr(user, UserModel.USERNAME_FIELD)
 

--- a/mozilla_django_oidc_db/templates/admin/oidc_account_merge.html
+++ b/mozilla_django_oidc_db/templates/admin/oidc_account_merge.html
@@ -1,0 +1,49 @@
+{% extends "admin/login.html" %}
+{% load i18n %}
+
+
+{% block content %}
+
+<div id="content-main">
+    <p>
+        {% blocktrans trimmed %}
+            An existing account with your email address was found.
+            Enter your current password to confirm you own this account.
+            After linking, you will log in exclusively through your organisation account.
+        {% endblocktrans %}
+    </p>
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+            <p class="errornote">
+                {% for error in form.non_field_errors %}{{ error }}{% endfor %}
+            </p>
+        {% endif %}
+
+        {% for field in form %}
+            <div class="form-row{% if field.errors %} errors{% endif %}">
+                {{ field.label_tag }}
+                {{ field }}
+                {% if field.errors %}
+                    <ul class="errorlist">
+                        {% for error in field.errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+        {% endfor %}
+
+        <div class="submit-row">
+            <input type="submit" value="{% trans "Link accounts" %}">
+        </div>
+    </form>
+
+    <p>
+        <a href="{% url 'admin:login' %}">{% trans "Cancel" %}</a>
+    </p>
+</div>
+
+{% endblock %}

--- a/mozilla_django_oidc_db/templates/mozilla_django_oidc_db/account_merge.html
+++ b/mozilla_django_oidc_db/templates/mozilla_django_oidc_db/account_merge.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% load i18n %}{% trans "Link your existing account" %}</title>
+</head>
+<body>
+    {% load i18n %}
+    <h1>{% trans "Link your existing account" %}</h1>
+
+    <p>
+        {% blocktrans trimmed %}
+            An existing account with your email address was found.
+            Enter your current password to confirm you own this account.
+            After linking, you will log in exclusively through your organisation account.
+        {% endblocktrans %}
+    </p>
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+
+        {% if form.errors %}
+            <ul>
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        {% for field in form %}
+            <div>
+                {{ field.label_tag }}
+                {{ field }}
+                {% if field.errors %}
+                    <ul>
+                        {% for error in field.errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if field.help_text %}
+                    <small>{{ field.help_text }}</small>
+                {% endif %}
+            </div>
+        {% endfor %}
+
+        <button type="submit">{% trans "Link accounts" %}</button>
+    </form>
+</body>
+</html>

--- a/mozilla_django_oidc_db/urls.py
+++ b/mozilla_django_oidc_db/urls.py
@@ -1,0 +1,35 @@
+"""
+URL patterns for the mozilla-django-oidc-db account-merge onboarding flow.
+
+Include these in your project's URL conf alongside the OIDC callback URL::
+
+    from django.urls import include, path
+
+    urlpatterns = [
+        # ... other urls ...
+        path("oidc/", include("mozilla_django_oidc.urls")),
+        path("oidc/", include("mozilla_django_oidc_db.urls")),
+    ]
+
+The admin-specific URL (``admin-oidc-account-merge``) is referenced by
+:class:`~mozilla_django_oidc_db.views.AdminCallbackView`; the generic URL
+(``oidc-account-merge``) is used by
+:class:`~mozilla_django_oidc_db.views.OIDCAuthenticationCallbackView`.
+"""
+
+from django.urls import path
+
+from .views import AdminAccountMergeView, OIDCAccountMergeView
+
+urlpatterns = [
+    path(
+        "account-merge/",
+        OIDCAccountMergeView.as_view(),
+        name="oidc-account-merge",
+    ),
+    path(
+        "admin/account-merge/",
+        AdminAccountMergeView.as_view(),
+        name="admin-oidc-account-merge",
+    ),
+]

--- a/mozilla_django_oidc_db/views.py
+++ b/mozilla_django_oidc_db/views.py
@@ -3,13 +3,14 @@ from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 from django.contrib import admin
+from django.contrib.auth import login as auth_login
 from django.core.exceptions import DisallowedRedirect, PermissionDenied, ValidationError
 from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
-from django.views.generic import TemplateView
+from django.views.generic import FormView, TemplateView
 
 import requests
 from mozilla_django_oidc.views import (
@@ -19,7 +20,8 @@ from mozilla_django_oidc.views import (
 
 from .config import get_setting_from_config, lookup_config, store_config
 from .constants import OIDC_ADMIN_CONFIG_IDENTIFIER
-from .exceptions import OIDCProviderOutage
+from .exceptions import AccountMergeRequired, OIDCProviderOutage
+from .forms import AccountMergeForm
 from .registry import register as registry
 from .typing import GetParams
 
@@ -44,6 +46,15 @@ which we deliberately do not rely on as their usage may change and it is private
 In some situations the value of this session key needs to be used as base to properly
 display problems (used in the ``failure_url`` flow of the callback view).
 """
+
+_OIDC_MERGE_CANDIDATE_PK_KEY = "oidc-merge-candidate-pk"
+"""Session key holding the primary key of the existing user to merge into."""
+
+_OIDC_MERGE_CLAIMS_KEY = "oidc-merge-claims"
+"""Session key holding the OIDC claims dict to apply after merging."""
+
+_OIDC_MERGE_CONFIG_KEY = "oidc-merge-config"
+"""Session key holding the OIDC config identifier for the merge flow."""
 
 
 def get_exception_message(exc: Exception) -> str:
@@ -84,6 +95,10 @@ class OIDCAuthenticationCallbackView(BaseOIDCCallbackView):
     Base callback view that retrieves the settings from the config object.
     """
 
+    #: URL name for the account-merge view.  Override in subclasses to point to
+    #: a differently named URL (e.g. an admin-styled version).
+    merge_view_url_name = "oidc-account-merge"
+
     def get_settings(self, attr: str, *args: Any) -> Any:  # type: ignore
         """
         Look up the request setting from the database config.
@@ -96,11 +111,31 @@ class OIDCAuthenticationCallbackView(BaseOIDCCallbackView):
             self._config = configuration
         return get_setting_from_config(configuration, attr, *args)
 
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponseBase:
+        try:
+            return super().get(request, *args, **kwargs)
+        except AccountMergeRequired as exc:
+            return self._handle_merge_required(request, exc)
+
+    def _handle_merge_required(
+        self, request: HttpRequest, exc: AccountMergeRequired
+    ) -> HttpResponseRedirect:
+        """
+        Persist the merge state in the session and redirect to the merge view.
+        """
+        config = lookup_config(request)
+        request.session[_OIDC_MERGE_CANDIDATE_PK_KEY] = exc.candidate.pk
+        request.session[_OIDC_MERGE_CLAIMS_KEY] = exc.claims
+        request.session[_OIDC_MERGE_CONFIG_KEY] = config.identifier
+        return HttpResponseRedirect(reverse(self.merge_view_url_name))
+
 
 class AdminCallbackView(OIDCAuthenticationCallbackView):
     """
     Intercept errors raised by the authentication backend and display them.
     """
+
+    merge_view_url_name = "admin-oidc-account-merge"
 
     @property
     def failure_url(self):
@@ -145,6 +180,100 @@ class AdminLoginFailure(TemplateView):
         context = super().get_context_data(**kwargs)
         context.update(admin.site.each_context(self.request))
         context["oidc_error"] = self.request.session[_OIDC_ERROR_SESSION_KEY]
+        return context
+
+
+class OIDCAccountMergeView(FormView):
+    """
+    One-time account-merge view presented when an OIDC identity matches an
+    existing Django account by email but not by username.
+
+    The user must confirm ownership of the existing account by supplying its
+    current password.  On success the existing user's username is renamed to the
+    OIDC identifier and the local password is cleared.
+
+    Register this view (or :class:`AdminAccountMergeView`) in your URL conf:
+
+    .. code-block:: python
+
+        from mozilla_django_oidc_db.views import OIDCAccountMergeView
+
+        urlpatterns = [
+            path("oidc/account-merge/", OIDCAccountMergeView.as_view(), name="oidc-account-merge"),
+        ]
+    """
+
+    form_class = AccountMergeForm
+    template_name = "mozilla_django_oidc_db/account_merge.html"
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponseBase:
+        # Guard: only accessible when a merge is pending in the session.
+        if _OIDC_MERGE_CANDIDATE_PK_KEY not in request.session:
+            raise PermissionDenied()
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user_pk"] = self.request.session[_OIDC_MERGE_CANDIDATE_PK_KEY]
+        return kwargs
+
+    def form_valid(self, form: AccountMergeForm) -> HttpResponseRedirect:
+        user = form.get_user()
+        claims = self.request.session[_OIDC_MERGE_CLAIMS_KEY]
+        config_identifier = self.request.session[_OIDC_MERGE_CONFIG_KEY]
+
+        plugin = registry[config_identifier]
+        plugin.merge_accounts(user, claims)
+
+        # Set the config identifier on the user so the user_logged_in signal
+        # can persist it on the session (required for SessionRefresh middleware).
+        user._oidcdb_config_identifier = config_identifier  # pyright: ignore[reportAttributeAccessIssue]
+
+        auth_login(
+            self.request,
+            user,
+            backend="mozilla_django_oidc_db.backends.OIDCAuthenticationBackend",
+        )
+
+        # Clean up merge session state.
+        for key in (
+            _OIDC_MERGE_CANDIDATE_PK_KEY,
+            _OIDC_MERGE_CLAIMS_KEY,
+            _OIDC_MERGE_CONFIG_KEY,
+        ):
+            self.request.session.pop(key, None)
+
+        return_url = self.request.session.get(_RETURN_URL_SESSION_KEY) or "/"
+        return HttpResponseRedirect(return_url)
+
+
+class AdminAccountMergeView(OIDCAccountMergeView):
+    """
+    Admin-styled variant of :class:`OIDCAccountMergeView`.
+
+    Uses the Django admin base template and redirects to the admin after a
+    successful merge.
+
+    Register this view in your URL conf:
+
+    .. code-block:: python
+
+        from mozilla_django_oidc_db.views import AdminAccountMergeView
+
+        urlpatterns = [
+            path(
+                "admin/login/account-merge/",
+                AdminAccountMergeView.as_view(),
+                name="admin-oidc-account-merge",
+            ),
+        ]
+    """
+
+    template_name = "admin/oidc_account_merge.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(admin.site.each_context(self.request))
         return context
 
 

--- a/mozilla_django_oidc_db/views.py
+++ b/mozilla_django_oidc_db/views.py
@@ -111,9 +111,9 @@ class OIDCAuthenticationCallbackView(BaseOIDCCallbackView):
             self._config = configuration
         return get_setting_from_config(configuration, attr, *args)
 
-    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponseBase:
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponseRedirect:
         try:
-            return super().get(request, *args, **kwargs)
+            return super().get(request, *args, **kwargs)  # type: ignore[return-value]
         except AccountMergeRequired as exc:
             return self._handle_merge_required(request, exc)
 

--- a/testapp/urls.py
+++ b/testapp/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
         name="login-keycloak-custom",
     ),
     path("oidc/", include("mozilla_django_oidc.urls")),
+    path("oidc/", include("mozilla_django_oidc_db.urls")),
 ] + staticfiles_urlpatterns()

--- a/tests/test_account_merge.py
+++ b/tests/test_account_merge.py
@@ -82,9 +82,7 @@ def test_create_user_raises_account_merge_required_when_email_matches(dummy_conf
     plugin = registry["test-oidc"]
 
     with pytest.raises(AccountMergeRequired) as exc_info:
-        plugin.create_user(
-            claims={"sub": "oidc-uuid-sub", "email": "user@example.com"}
-        )
+        plugin.create_user(claims={"sub": "oidc-uuid-sub", "email": "user@example.com"})
 
     assert exc_info.value.candidate == existing
     assert exc_info.value.claims["sub"] == "oidc-uuid-sub"

--- a/tests/test_account_merge.py
+++ b/tests/test_account_merge.py
@@ -27,9 +27,8 @@ from mozilla_django_oidc_db.views import (
 )
 from testapp.backends import MockBackend
 
-from .conftest import callback_request_mark as callback_request, oidcconfig
+from .conftest import oidcconfig
 from .factories import UserFactory
-
 
 # ---------------------------------------------------------------------------
 # Fixtures shared across callback-level tests

--- a/tests/test_account_merge.py
+++ b/tests/test_account_merge.py
@@ -1,0 +1,352 @@
+"""
+Tests for the OIDC account-merge onboarding flow (issue #122).
+
+The flow is triggered when:
+- ``allow_account_merge`` is enabled on the OIDCClient
+- The OIDC username claim does not match any existing Django user
+- But the OIDC email claim *does* match an existing Django user (same email)
+
+The user is redirected to a password-confirmation form, and on success the
+existing user's username is renamed to the OIDC identifier and the local
+password is cleared.
+"""
+
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+import pytest
+
+from mozilla_django_oidc_db.exceptions import AccountMergeRequired
+from mozilla_django_oidc_db.models import UserInformationClaimsSources
+from mozilla_django_oidc_db.registry import register as registry
+from mozilla_django_oidc_db.views import (
+    _OIDC_MERGE_CANDIDATE_PK_KEY,
+    _OIDC_MERGE_CLAIMS_KEY,
+    _OIDC_MERGE_CONFIG_KEY,
+)
+from testapp.backends import MockBackend
+
+from .conftest import callback_request_mark as callback_request, oidcconfig
+from .factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared across callback-level tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_auth_backend(request, mocker):
+    """Patch Django auth backends with a MockBackend using the given claims."""
+    marker = request.node.get_closest_marker("mock_backend_claims")
+    claims = marker.args[0] if marker else {"sub": "some_username"}
+    mock_backend = MockBackend(claims=claims)
+    backend_path = f"{MockBackend.__module__}.{MockBackend.__qualname__}"
+    mocker.patch(
+        "django.contrib.auth._get_backends",
+        return_value=[(mock_backend, backend_path)],
+    )
+    return mock_backend
+
+
+@pytest.fixture
+def callback_client(callback_request, client: Client) -> Client:
+    """A test client whose session is pre-populated from the OIDC auth request."""
+    session = client.session
+    for key, value in callback_request.session.items():
+        session[key] = value
+    session.save()
+    return client
+
+
+mock_backend_claims = pytest.mark.mock_backend_claims
+
+
+# ---------------------------------------------------------------------------
+# Plugin-level tests
+# ---------------------------------------------------------------------------
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_create_user_raises_account_merge_required_when_email_matches(dummy_config):
+    """AccountMergeRequired is raised when the email claim matches an existing user."""
+    existing = UserFactory.create(username="existing-local", email="user@example.com")
+    plugin = registry["test-oidc"]
+
+    with pytest.raises(AccountMergeRequired) as exc_info:
+        plugin.create_user(
+            claims={"sub": "oidc-uuid-sub", "email": "user@example.com"}
+        )
+
+    assert exc_info.value.candidate == existing
+    assert exc_info.value.claims["sub"] == "oidc-uuid-sub"
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=False,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_create_user_does_not_raise_when_merge_disabled(dummy_config):
+    """No AccountMergeRequired when allow_account_merge is False (default)."""
+    UserFactory.create(username="existing-local", email="user@example.com")
+    plugin = registry["test-oidc"]
+
+    # Should create a new user, not raise.
+    user = plugin.create_user(
+        claims={"sub": "oidc-uuid-sub", "email": "user@example.com"}
+    )
+
+    assert user.username == "oidc-uuid-sub"
+    assert User.objects.count() == 2
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_create_user_no_raise_when_no_email_match(dummy_config):
+    """No AccountMergeRequired when the email does not match any existing user."""
+    plugin = registry["test-oidc"]
+
+    user = plugin.create_user(
+        claims={"sub": "oidc-uuid-sub", "email": "new@example.com"}
+    )
+
+    assert user.username == "oidc-uuid-sub"
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": [],  # explicitly no email claim path
+    },
+)
+@pytest.mark.django_db
+def test_create_user_no_raise_when_no_email_claim_configured(dummy_config):
+    """No AccountMergeRequired when no email claim path is configured."""
+    UserFactory.create(username="existing-local", email="user@example.com")
+    plugin = registry["test-oidc"]
+
+    user = plugin.create_user(
+        claims={"sub": "oidc-uuid-sub", "email": "user@example.com"}
+    )
+
+    assert user.username == "oidc-uuid-sub"
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+        "user_settings.claim_mappings.first_name": ["given_name"],
+    },
+)
+@pytest.mark.django_db
+def test_merge_accounts_renames_username_and_clears_password(dummy_config):
+    """merge_accounts renames the username and sets an unusable password."""
+    existing = UserFactory.create(
+        username="existing-local",
+        email="user@example.com",
+        first_name="Old",
+    )
+    existing.set_password("secret123")
+    existing.save()
+
+    plugin = registry["test-oidc"]
+    merged = plugin.merge_accounts(
+        existing,
+        claims={
+            "sub": "oidc-uuid-sub",
+            "email": "user@example.com",
+            "given_name": "New",
+        },
+    )
+
+    merged.refresh_from_db()
+    assert merged.pk == existing.pk  # same record
+    assert merged.username == "oidc-uuid-sub"
+    assert not merged.has_usable_password()
+    assert merged.first_name == "New"
+
+
+# ---------------------------------------------------------------------------
+# Callback-view-level tests: redirect to merge view
+# ---------------------------------------------------------------------------
+
+
+@mock_backend_claims({"sub": "oidc-uuid", "email": "user@example.com"})
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    userinfo_claims_source=UserInformationClaimsSources.id_token,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_callback_redirects_to_merge_view_on_email_clash(
+    dummy_config,
+    callback_request,
+    callback_client: Client,
+    mock_auth_backend,
+):
+    """
+    When an email clash is detected the callback view redirects to the
+    account-merge URL and stores the necessary state in the session.
+    """
+    existing = UserFactory.create(username="existing-local", email="user@example.com")
+
+    callback_url = reverse("oidc_authentication_callback")
+    response = callback_client.get(callback_url, {**callback_request.GET})
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse("admin-oidc-account-merge")
+
+    session = callback_client.session
+    assert session[_OIDC_MERGE_CANDIDATE_PK_KEY] == existing.pk
+    assert session[_OIDC_MERGE_CLAIMS_KEY]["sub"] == "oidc-uuid"
+    assert session[_OIDC_MERGE_CONFIG_KEY] == "test-oidc"
+
+
+# ---------------------------------------------------------------------------
+# Merge view (form) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_merge_view_inaccessible_without_session_state(client):
+    """Direct access to the merge URL without a pending merge raises 403."""
+    response = client.get(reverse("admin-oidc-account-merge"))
+    assert response.status_code == 403
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_merge_view_wrong_password_shows_error(client, dummy_config):
+    """Submitting a wrong password re-renders the form with an error."""
+    existing = UserFactory.create(username="local-user", email="u@example.com")
+    existing.set_password("correct-password")
+    existing.save()
+
+    session = client.session
+    session[_OIDC_MERGE_CANDIDATE_PK_KEY] = existing.pk
+    session[_OIDC_MERGE_CLAIMS_KEY] = {"sub": "oidc-uuid", "email": "u@example.com"}
+    session[_OIDC_MERGE_CONFIG_KEY] = "test-oidc"
+    session.save()
+
+    response = client.post(
+        reverse("admin-oidc-account-merge"),
+        data={"password": "wrong-password"},
+    )
+
+    assert response.status_code == 200
+    assert "Incorrect password" in response.content.decode()
+    # User must NOT be merged.
+    existing.refresh_from_db()
+    assert existing.username == "local-user"
+    assert existing.has_usable_password()
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_merge_view_correct_password_merges_and_logs_in(client, dummy_config):
+    """Correct password triggers the merge and logs the user in."""
+    existing = UserFactory.create(username="local-user", email="u@example.com")
+    existing.set_password("correct-password")
+    existing.save()
+
+    session = client.session
+    session[_OIDC_MERGE_CANDIDATE_PK_KEY] = existing.pk
+    session[_OIDC_MERGE_CLAIMS_KEY] = {"sub": "oidc-uuid", "email": "u@example.com"}
+    session[_OIDC_MERGE_CONFIG_KEY] = "test-oidc"
+    session.save()
+
+    response = client.post(
+        reverse("admin-oidc-account-merge"),
+        data={"password": "correct-password"},
+        follow=False,
+    )
+
+    assert response.status_code == 302
+
+    existing.refresh_from_db()
+    assert existing.username == "oidc-uuid"
+    assert not existing.has_usable_password()
+
+    # Session merge keys must be cleaned up.
+    updated_session = client.session
+    assert _OIDC_MERGE_CANDIDATE_PK_KEY not in updated_session
+    assert _OIDC_MERGE_CLAIMS_KEY not in updated_session
+    assert _OIDC_MERGE_CONFIG_KEY not in updated_session
+
+
+@oidcconfig(
+    enabled=True,
+    allow_account_merge=True,
+    extra_options={
+        "user_settings.claim_mappings.username": ["sub"],
+        "user_settings.claim_mappings.email": ["email"],
+    },
+)
+@pytest.mark.django_db
+def test_merge_view_redirects_to_return_url(client, dummy_config):
+    """After a successful merge the user is redirected to the stored return URL."""
+    from mozilla_django_oidc_db.views import _RETURN_URL_SESSION_KEY
+
+    existing = UserFactory.create(username="local-user", email="u@example.com")
+    existing.set_password("pw")
+    existing.save()
+
+    session = client.session
+    session[_OIDC_MERGE_CANDIDATE_PK_KEY] = existing.pk
+    session[_OIDC_MERGE_CLAIMS_KEY] = {"sub": "oidc-uuid", "email": "u@example.com"}
+    session[_OIDC_MERGE_CONFIG_KEY] = "test-oidc"
+    session[_RETURN_URL_SESSION_KEY] = "/admin/"
+    session.save()
+
+    response = client.post(
+        reverse("admin-oidc-account-merge"),
+        data={"password": "pw"},
+        follow=False,
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/admin/"

--- a/tests/test_account_merge.py
+++ b/tests/test_account_merge.py
@@ -20,6 +20,7 @@ import pytest
 from mozilla_django_oidc_db.exceptions import AccountMergeRequired
 from mozilla_django_oidc_db.models import UserInformationClaimsSources
 from mozilla_django_oidc_db.registry import register as registry
+from mozilla_django_oidc_db.typing import JSONObject
 from mozilla_django_oidc_db.views import (
     _OIDC_MERGE_CANDIDATE_PK_KEY,
     _OIDC_MERGE_CLAIMS_KEY,
@@ -39,7 +40,7 @@ from .factories import UserFactory
 def mock_auth_backend(request, mocker):
     """Patch Django auth backends with a MockBackend using the given claims."""
     marker = request.node.get_closest_marker("mock_backend_claims")
-    claims = marker.args[0] if marker else {"sub": "some_username"}
+    claims: JSONObject = marker.args[0] if marker else {"sub": "some_username"}
     mock_backend = MockBackend(claims=claims)
     backend_path = f"{MockBackend.__module__}.{MockBackend.__qualname__}"
     mocker.patch(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,6 +36,7 @@ class OIDCConfigOptions(TypedDict, total=False):
     oidc_rp_idp_sign_key: str
     oidc_keycloak_idp_hint: str
     userinfo_claims_source: UserInformationClaimsSources
+    allow_account_merge: bool
     check_op_availability: bool
     options: JSONObject
     extra_options: JSONObject


### PR DESCRIPTION
  Closes #122                                                                                                  
                  
  ## Problem

  When a user with an existing Django account (created before OIDC was configured) logs in via OIDC for the      first time, the OIDC username claim (typically a Keycloak UUID `sub`) does not match their local username.
  This results in either a duplicate account being silently created, or an `IntegrityError` on a unique email    constraint — leaving the user unable to log in cleanly.

  ## Solution                                                                                                  
  
  A one-time **account-merge onboarding flow**, keeping the existing user record fully intact (audit logs,       permissions, groups, FK references). Only the username is renamed to the OIDC identifier and the local  password is cleared.

  ### Flow

  ```
  OIDC callback
    ├─ username match found → normal login (unchanged)
    └─ no username match                                                                                       
         ├─ email match found AND allow_account_merge=True
         │    └─ store claims in session → redirect to merge view                                              
         │         ├─ wrong password → re-show form with error
         │         └─ correct password                                                                         
         │              → rename username to OIDC sub
         │              → clear local password                                                                 
         │              → sync other claim fields (email, first_name, …)
         │              └─ log in, redirect to stored return URL
         └─ no email match → create new user (existing behaviour)                                              
  ```
                                                                                                               
  ### Opt-in      

  The feature is **disabled by default** (`allow_account_merge = False`). Enable it per `OIDCClient` in the      Django admin or programmatically:
                                                                                                               
  ```python       
  OIDCClient.objects.filter(identifier="admin-oidc").update(allow_account_merge=True)
  ```

  ### URL setup

  Include the library's URL patterns in your project URL conf alongside `mozilla_django_oidc.urls`:            
  
  ```python                                                                                                    
  from django.urls import include, path

  urlpatterns = [
      path("oidc/", include("mozilla_django_oidc.urls")),
      path("oidc/", include("mozilla_django_oidc_db.urls")),  # registers merge URLs
  ]                                                                                                            
  ```
                                                                                                               
  This adds two named URLs:
  - `oidc-account-merge` — generic merge view (`OIDCAccountMergeView`)
  - `admin-oidc-account-merge` — admin-styled merge view (`AdminAccountMergeView`, used automatically by
  `AdminCallbackView`)                                                                                         
  
  ## Test plan                                                                                                 
                  
  - [ ] `test_create_user_raises_account_merge_required_when_email_matches` — exception raised when email        matches and merge is enabled
  - [ ] `test_create_user_does_not_raise_when_merge_disabled` — no exception when `allow_account_merge=False`  
  - [ ] `test_create_user_no_raise_when_no_email_match` — no exception when email does not match any existing  user                                                                                                         
  - [ ] `test_create_user_no_raise_when_no_email_claim_configured` — no exception when no email claim path is  configured                                                                                                   
  - [ ] `test_merge_accounts_renames_username_and_clears_password` — username renamed, password cleared, other  mapped fields synced                                                                                         
  - [ ] `test_callback_redirects_to_merge_view_on_email_clash` — full callback flow redirects to merge URL and  stores correct session state                                                                                 
  - [ ] `test_merge_view_inaccessible_without_session_state` — direct GET without pending merge returns 403
  - [ ] `test_merge_view_wrong_password_shows_error` — wrong password re-renders form, no merge occurs         
  - [ ] `test_merge_view_correct_password_merges_and_logs_in` — correct password merges account and logs user  in, session keys cleaned up                                                                                  
  - [ ] `test_merge_view_redirects_to_return_url` — redirects to the stored return URL after successful merge
                                                                                                               
  🤖 Generated with [Claude Code](https://claude.com/claude-code)